### PR TITLE
fix: resolve all CI lint errors in settings components and API keys DTO

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
 
 import { PrismaModule } from './common/prisma/prisma.module';
 import { AiModule } from './modules/ai/ai.module';
+import { ApiKeysModule } from './modules/api-keys/api-keys.module';
 import { AuditsModule } from './modules/audits/audits.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { BlockchainModule } from './modules/blockchain/blockchain.module';
@@ -34,6 +35,7 @@ import { UsersModule } from './modules/users/users.module';
     AuditsModule,
     ReportsModule,
     AiModule,
+    ApiKeysModule,
     BlockchainModule,
     NotificationsModule,
   ],

--- a/apps/api/src/modules/api-keys/api-keys.controller.ts
+++ b/apps/api/src/modules/api-keys/api-keys.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ApiKeysService } from './api-keys.service';
+import { CreateApiKeyDto } from './dto/api-key.dto';
+
+@ApiTags('API Keys')
+@Controller('api-keys')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class ApiKeysController {
+  constructor(private readonly apiKeysService: ApiKeysService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all API keys for current user' })
+  findAll(@CurrentUser('id') userId: string) {
+    return this.apiKeysService.findByUser(userId);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new API key' })
+  create(@CurrentUser('id') userId: string, @Body() dto: CreateApiKeyDto) {
+    return this.apiKeysService.create(userId, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Revoke an API key' })
+  revoke(@CurrentUser('id') userId: string, @Param('id') keyId: string) {
+    return this.apiKeysService.revoke(userId, keyId);
+  }
+}

--- a/apps/api/src/modules/api-keys/api-keys.module.ts
+++ b/apps/api/src/modules/api-keys/api-keys.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ApiKeysController } from './api-keys.controller';
+import { ApiKeysService } from './api-keys.service';
+
+@Module({
+  controllers: [ApiKeysController],
+  providers: [ApiKeysService],
+  exports: [ApiKeysService],
+})
+export class ApiKeysModule {}

--- a/apps/api/src/modules/api-keys/api-keys.service.ts
+++ b/apps/api/src/modules/api-keys/api-keys.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+
+import { PrismaService } from '../../common/prisma/prisma.service';
+import type { CreateApiKeyDto } from './dto/api-key.dto';
+
+@Injectable()
+export class ApiKeysService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByUser(userId: string) {
+    return this.prisma.db.apiKey.findMany({
+      where: { userId, isActive: true },
+      select: {
+        id: true,
+        name: true,
+        isActive: true,
+        lastUsedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async create(userId: string, dto: CreateApiKeyDto) {
+    const generatedKey = `ver_${randomBytes(24).toString('hex')}`;
+
+    const apiKey = await this.prisma.db.apiKey.create({
+      data: {
+        userId,
+        name: dto.name,
+        key: generatedKey,
+        permissions: ['read'],
+      },
+    });
+
+    return {
+      id: apiKey.id,
+      name: apiKey.name,
+      key: apiKey.key,
+      isActive: apiKey.isActive,
+      createdAt: apiKey.createdAt,
+      updatedAt: apiKey.updatedAt,
+    };
+  }
+
+  async revoke(userId: string, keyId: string) {
+    const key = await this.prisma.db.apiKey.findFirst({
+      where: { id: keyId, userId },
+    });
+
+    if (!key || !key.isActive) {
+      throw new NotFoundException('API key not found');
+    }
+
+    await this.prisma.db.apiKey.update({
+      where: { id: keyId },
+      data: { isActive: false },
+    });
+
+    return { message: 'API key revoked successfully' };
+  }
+}

--- a/apps/api/src/modules/api-keys/api-keys.service.ts
+++ b/apps/api/src/modules/api-keys/api-keys.service.ts
@@ -17,7 +17,6 @@ export class ApiKeysService {
         isActive: true,
         lastUsedAt: true,
         createdAt: true,
-        updatedAt: true,
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -41,7 +40,6 @@ export class ApiKeysService {
       key: apiKey.key,
       isActive: apiKey.isActive,
       createdAt: apiKey.createdAt,
-      updatedAt: apiKey.updatedAt,
     };
   }
 

--- a/apps/api/src/modules/api-keys/dto/api-key.dto.ts
+++ b/apps/api/src/modules/api-keys/dto/api-key.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateApiKeyDto {
+  @ApiProperty({ example: 'Production API Key' })
+  @IsString()
+  @MaxLength(100)
+  name: string;
+}
+
+export class ApiKeyResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiPropertyOptional()
+  key?: string;
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiPropertyOptional()
+  lastUsedAt: Date | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+}

--- a/apps/api/src/modules/api-keys/dto/api-key.dto.ts
+++ b/apps/api/src/modules/api-keys/dto/api-key.dto.ts
@@ -26,7 +26,4 @@ export class ApiKeyResponseDto {
 
   @ApiProperty()
   createdAt: Date;
-
-  @ApiProperty()
-  updatedAt: Date;
 }

--- a/apps/api/src/modules/api-keys/dto/api-key.dto.ts
+++ b/apps/api/src/modules/api-keys/dto/api-key.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsString, MaxLength } from 'class-validator';
 
 export class CreateApiKeyDto {
   @ApiProperty({ example: 'Production API Key' })

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -11,6 +11,14 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000'}/api/v1/:path*`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -1,73 +1,184 @@
+'use client';
+
+import { Bell, Key, Palette, Shield, User, Wallet } from 'lucide-react';
+import { useState } from 'react';
+
+import { ApiKeysList } from '@/components/settings/api-keys-list';
+import { ProfileForm } from '@/components/settings/profile-form';
+import { WalletSection } from '@/components/settings/wallet-section';
+
+const tabs = [
+  { id: 'profile', label: 'Profile', icon: User },
+  { id: 'wallet', label: 'Wallet', icon: Wallet },
+  { id: 'api-keys', label: 'API Keys', icon: Key },
+  { id: 'notifications', label: 'Notifications', icon: Bell },
+  { id: 'appearance', label: 'Appearance', icon: Palette },
+] as const;
+
+type TabId = (typeof tabs)[number]['id'];
+
 export default function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('profile');
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
         <p className="text-muted-foreground mt-1">
-          Manage your account, API keys, and preferences.
+          Manage your account, wallet, API keys, and preferences.
         </p>
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="space-y-4 lg:col-span-2">
-          <div className="bg-card rounded-xl border p-6">
-            <h2 className="text-lg font-semibold">Profile</h2>
-            <div className="mt-4 space-y-4">
-              <div>
-                <label className="text-sm font-medium">Display Name</label>
-                <input
-                  type="text"
-                  className="bg-background mt-1 w-full rounded-lg border px-3 py-2 text-sm"
-                  placeholder="Your name"
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium">Email</label>
-                <input
-                  type="email"
-                  className="bg-background mt-1 w-full rounded-lg border px-3 py-2 text-sm"
-                  placeholder="you@example.com"
-                  disabled
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium">Wallet Address (Stellar)</label>
-                <input
-                  type="text"
-                  className="bg-background mt-1 w-full rounded-lg border px-3 py-2 font-mono text-sm"
-                  placeholder="G..."
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-card rounded-xl border p-6">
-            <h2 className="text-lg font-semibold">API Keys</h2>
-            <p className="text-muted-foreground mt-2 text-sm">
-              Manage API keys for programmatic access to Veridion.
-            </p>
-            <button className="bg-primary text-primary-foreground hover:bg-primary/90 mt-4 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors">
-              Generate New API Key
-            </button>
-          </div>
+      <div className="grid gap-6 lg:grid-cols-4">
+        {/* Sidebar navigation */}
+        <div className="bg-card h-fit rounded-xl border p-2">
+          <nav className="space-y-1">
+            {tabs.map((tab) => {
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                    activeTab === tab.id
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                  }`}
+                >
+                  <Icon className="h-5 w-5 shrink-0" />
+                  {tab.label}
+                </button>
+              );
+            })}
+          </nav>
         </div>
 
-        <div className="bg-card h-fit rounded-xl border p-6">
-          <h2 className="text-lg font-semibold">Preferences</h2>
-          <div className="mt-4 space-y-3">
-            <label className="flex items-center gap-3">
-              <input type="checkbox" className="h-4 w-4" defaultChecked />
-              <span className="text-sm">Email notifications for audit completion</span>
-            </label>
-            <label className="flex items-center gap-3">
-              <input type="checkbox" className="h-4 w-4" defaultChecked />
-              <span className="text-sm">Critical finding alerts</span>
-            </label>
-            <label className="flex items-center gap-3">
-              <input type="checkbox" className="h-4 w-4" />
-              <span className="text-sm">Weekly security digest</span>
-            </label>
-          </div>
+        {/* Main content */}
+        <div className="min-w-0 space-y-6 lg:col-span-3">
+          {activeTab === 'profile' && <ProfileForm />}
+
+          {activeTab === 'wallet' && <WalletSection />}
+
+          {activeTab === 'api-keys' && <ApiKeysList />}
+
+          {activeTab === 'notifications' && (
+            <div className="bg-card rounded-xl border p-6">
+              <div className="flex items-start gap-3">
+                <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
+                  <Bell className="text-primary h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold">Notification Preferences</h2>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    Configure which notifications you receive.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6 space-y-4">
+                <label className="hover:bg-muted/50 flex items-center gap-3 rounded-lg border p-4 transition-colors">
+                  <input
+                    type="checkbox"
+                    className="border-input text-primary focus:ring-ring h-4 w-4 rounded"
+                    defaultChecked
+                  />
+                  <div>
+                    <span className="text-sm font-medium">
+                      Email notifications for audit completion
+                    </span>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Receive an email when an audit completes successfully.
+                    </p>
+                  </div>
+                </label>
+                <label className="hover:bg-muted/50 flex items-center gap-3 rounded-lg border p-4 transition-colors">
+                  <input
+                    type="checkbox"
+                    className="border-input text-primary focus:ring-ring h-4 w-4 rounded"
+                    defaultChecked
+                  />
+                  <div>
+                    <span className="text-sm font-medium">Critical finding alerts</span>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Get notified immediately when critical vulnerabilities are found.
+                    </p>
+                  </div>
+                </label>
+                <label className="hover:bg-muted/50 flex items-center gap-3 rounded-lg border p-4 transition-colors">
+                  <input
+                    type="checkbox"
+                    className="border-input text-primary focus:ring-ring h-4 w-4 rounded"
+                  />
+                  <div>
+                    <span className="text-sm font-medium">Weekly security digest</span>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Receive a weekly summary of all your project security statuses.
+                    </p>
+                  </div>
+                </label>
+              </div>
+
+              <div className="bg-muted/30 mt-6 rounded-lg border p-4">
+                <p className="text-muted-foreground text-sm">
+                  <Shield className="text-primary mr-1 inline h-4 w-4" />
+                  Notification preferences are saved locally. Full sync coming soon.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'appearance' && (
+            <div className="bg-card rounded-xl border p-6">
+              <div className="flex items-start gap-3">
+                <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
+                  <Palette className="text-primary h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold">Appearance</h2>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    Customize the look and feel of Veridion.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6 space-y-4">
+                <label className="hover:bg-muted/50 flex items-center gap-3 rounded-lg border p-4 transition-colors">
+                  <input
+                    type="radio"
+                    name="theme"
+                    className="text-primary focus:ring-ring h-4 w-4"
+                    defaultChecked
+                  />
+                  <div>
+                    <span className="text-sm font-medium">Dark Mode</span>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Default theme. Easy on the eyes for late-night coding.
+                    </p>
+                  </div>
+                </label>
+                <label className="hover:bg-muted/50 flex items-center gap-3 rounded-lg border p-4 transition-colors">
+                  <input
+                    type="radio"
+                    name="theme"
+                    className="text-primary focus:ring-ring h-4 w-4"
+                  />
+                  <div>
+                    <span className="text-sm font-medium">Light Mode</span>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Bright theme for daytime use.
+                    </p>
+                  </div>
+                </label>
+              </div>
+
+              <div className="bg-muted/30 mt-6 rounded-lg border p-4">
+                <p className="text-muted-foreground text-sm">
+                  <Shield className="text-primary mr-1 inline h-4 w-4" />
+                  Theme switching is managed by your system preferences by default.
+                </p>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/settings/api-keys-list.tsx
+++ b/apps/web/src/components/settings/api-keys-list.tsx
@@ -11,7 +11,6 @@ interface ApiKey {
   isActive: boolean;
   lastUsedAt: string | null;
   createdAt: string;
-  updatedAt: string;
 }
 
 interface CreateApiKeyResponse extends ApiKey {
@@ -23,7 +22,7 @@ async function fetchApiKeys(): Promise<ApiKey[]> {
     credentials: 'include',
   });
   if (!res.ok) throw new Error('Failed to fetch API keys');
-  return res.json();
+  return res.json() as Promise<ApiKey[]>;
 }
 
 async function createApiKey(name: string): Promise<CreateApiKeyResponse> {
@@ -34,7 +33,7 @@ async function createApiKey(name: string): Promise<CreateApiKeyResponse> {
     body: JSON.stringify({ name }),
   });
   if (!res.ok) throw new Error('Failed to create API key');
-  return res.json();
+  return res.json() as Promise<CreateApiKeyResponse>;
 }
 
 async function revokeApiKey(keyId: string): Promise<void> {
@@ -68,7 +67,7 @@ export function ApiKeysList() {
   const revokeMutation = useMutation({
     mutationFn: revokeApiKey,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      void queryClient.invalidateQueries({ queryKey: ['api-keys'] });
       toast.success('API key revoked successfully');
     },
     onError: (err: Error) => {
@@ -96,7 +95,7 @@ export function ApiKeysList() {
   const createMutation = useMutation({
     mutationFn: createApiKey,
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      void queryClient.invalidateQueries({ queryKey: ['api-keys'] });
       setCreatedKey(data.key);
       setShowCreate(false);
       setNewKeyName('');
@@ -115,7 +114,7 @@ export function ApiKeysList() {
   };
 
   const handleCopyKey = (key: string) => {
-    navigator.clipboard.writeText(key);
+    void navigator.clipboard.writeText(key);
     toast.success('API key copied to clipboard');
   };
 
@@ -231,9 +230,11 @@ export function ApiKeysList() {
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <Key className="text-muted-foreground/30 h-10 w-10" />
             <p className="text-muted-foreground mt-3 text-sm">Failed to load API keys</p>
-            <p className="text-muted-foreground text-xs">{(error as Error)?.message}</p>
+            <p className="text-muted-foreground text-xs">{error?.message}</p>
             <button
-              onClick={() => refetch()}
+              onClick={() => {
+                void refetch();
+              }}
               className="text-primary mt-3 inline-flex items-center gap-1.5 text-sm font-medium hover:underline"
             >
               <RefreshCw className="h-3.5 w-3.5" />

--- a/apps/web/src/components/settings/api-keys-list.tsx
+++ b/apps/web/src/components/settings/api-keys-list.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Copy, Key, Loader2, Plus, RefreshCw, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+interface ApiKey {
+  id: string;
+  name: string;
+  isActive: boolean;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateApiKeyResponse extends ApiKey {
+  key: string;
+}
+
+async function fetchApiKeys(): Promise<ApiKey[]> {
+  const res = await fetch('/api/api-keys', {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to fetch API keys');
+  return res.json();
+}
+
+async function createApiKey(name: string): Promise<CreateApiKeyResponse> {
+  const res = await fetch('/api/api-keys', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error('Failed to create API key');
+  return res.json();
+}
+
+async function revokeApiKey(keyId: string): Promise<void> {
+  const res = await fetch(`/api/api-keys/${keyId}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to revoke API key');
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return 'Never';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(dateStr));
+  } catch {
+    return dateStr;
+  }
+}
+
+export function ApiKeysList() {
+  const queryClient = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+  const [newKeyName, setNewKeyName] = useState('');
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const revokeMutation = useMutation({
+    mutationFn: revokeApiKey,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      toast.success('API key revoked successfully');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to revoke API key');
+    },
+  });
+
+  // Track which key is being revoked for per-button loading state
+  const revokingId =
+    revokeMutation.isPending && typeof revokeMutation.variables === 'string'
+      ? revokeMutation.variables
+      : null;
+
+  const {
+    data: apiKeys,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<ApiKey[]>({
+    queryKey: ['api-keys'],
+    queryFn: fetchApiKeys,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createApiKey,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      setCreatedKey(data.key);
+      setShowCreate(false);
+      setNewKeyName('');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to create API key');
+    },
+  });
+
+  const handleCreate = () => {
+    if (!newKeyName.trim()) {
+      toast.error('Please enter a name for the API key');
+      return;
+    }
+    createMutation.mutate(newKeyName.trim());
+  };
+
+  const handleCopyKey = (key: string) => {
+    navigator.clipboard.writeText(key);
+    toast.success('API key copied to clipboard');
+  };
+
+  const handleDismissNewKey = () => {
+    setCreatedKey(null);
+  };
+
+  return (
+    <div className="bg-card rounded-xl border p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">API Keys</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Manage API keys for programmatic access to Veridion.
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+        >
+          <Plus className="h-4 w-4" />
+          New Key
+        </button>
+      </div>
+
+      {/* Created key banner */}
+      {createdKey && (
+        <div className="mt-4 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+                API Key Created
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                Copy this key now. You won&apos;t be able to see it again.
+              </p>
+              <div className="bg-background mt-2 flex items-center justify-between rounded-lg border p-2.5">
+                <code className="break-all font-mono text-xs">{createdKey}</code>
+                <button
+                  onClick={() => handleCopyKey(createdKey)}
+                  className="text-muted-foreground hover:text-foreground ml-2 shrink-0 rounded-md p-1.5 transition-colors"
+                  title="Copy key"
+                >
+                  <Copy className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+            <button
+              onClick={handleDismissNewKey}
+              className="text-muted-foreground hover:text-foreground ml-3 rounded-md p-1 transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Create form */}
+      {showCreate && (
+        <div className="mt-4 rounded-lg border p-4">
+          <label htmlFor="newKeyName" className="text-sm font-medium">
+            Key Name
+          </label>
+          <div className="mt-1.5 flex items-center gap-2">
+            <input
+              id="newKeyName"
+              type="text"
+              value={newKeyName}
+              onChange={(e) => setNewKeyName(e.target.value)}
+              placeholder="e.g., Production API Key"
+              maxLength={100}
+              autoFocus
+              className="bg-background placeholder:text-muted-foreground focus:ring-ring flex-1 rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleCreate();
+                }
+                if (e.key === 'Escape') {
+                  setShowCreate(false);
+                  setNewKeyName('');
+                }
+              }}
+            />
+            <button
+              onClick={handleCreate}
+              disabled={createMutation.isPending}
+              className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50"
+            >
+              {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Generate'}
+            </button>
+            <button
+              onClick={() => {
+                setShowCreate(false);
+                setNewKeyName('');
+              }}
+              disabled={createMutation.isPending}
+              className="hover:bg-muted inline-flex items-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Keys list */}
+      <div className="mt-5">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Key className="text-muted-foreground/30 h-10 w-10" />
+            <p className="text-muted-foreground mt-3 text-sm">Failed to load API keys</p>
+            <p className="text-muted-foreground text-xs">{(error as Error)?.message}</p>
+            <button
+              onClick={() => refetch()}
+              className="text-primary mt-3 inline-flex items-center gap-1.5 text-sm font-medium hover:underline"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Try again
+            </button>
+          </div>
+        ) : apiKeys && apiKeys.length > 0 ? (
+          <div className="divide-y">
+            {apiKeys.map((key) => (
+              <div
+                key={key.id}
+                className="hover:bg-muted/50 flex items-center justify-between px-1 py-3 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg">
+                    <Key className="text-primary h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">{key.name}</p>
+                    <p className="text-muted-foreground text-xs">
+                      Created {formatDate(key.createdAt)}
+                      {key.lastUsedAt
+                        ? ` · Last used ${formatDate(key.lastUsedAt)}`
+                        : ' · Never used'}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => {
+                    if (window.confirm(`Revoke "${key.name}"? This action cannot be undone.`)) {
+                      revokeMutation.mutate(key.id);
+                    }
+                  }}
+                  disabled={revokeMutation.isPending && revokingId === key.id}
+                  className="text-muted-foreground hover:text-destructive rounded-md p-2 transition-colors disabled:opacity-50"
+                  title="Revoke key"
+                >
+                  {revokingId === key.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Key className="text-muted-foreground/30 h-10 w-10" />
+            <p className="text-muted-foreground mt-3 text-sm font-medium">No API keys yet</p>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Create an API key to get started with programmatic access.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/profile-form.tsx
+++ b/apps/web/src/components/settings/profile-form.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2, Save } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import type { User } from '@veridion/sdk';
+import { cn } from '@/lib/utils';
+
+const profileSchema = z.object({
+  displayName: z
+    .string()
+    .min(1, 'Display name is required')
+    .max(50, 'Display name must be 50 characters or less'),
+  avatarUrl: z.string().url('Must be a valid URL').nullable().optional().or(z.literal('')),
+});
+
+type ProfileFormData = z.infer<typeof profileSchema>;
+
+async function fetchProfile(): Promise<User> {
+  const res = await fetch('/api/users/me', {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to fetch profile');
+  return res.json();
+}
+
+async function updateProfile(data: ProfileFormData): Promise<User> {
+  const res = await fetch('/api/users/me', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update profile');
+  return res.json();
+}
+
+export function ProfileForm() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: profile,
+    isLoading,
+    isError,
+    error,
+  } = useQuery<User>({
+    queryKey: ['profile'],
+    queryFn: fetchProfile,
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      displayName: '',
+      avatarUrl: '',
+    },
+  });
+
+  useEffect(() => {
+    if (profile) {
+      reset({
+        displayName: profile.displayName ?? '',
+        avatarUrl: profile.avatarUrl ?? '',
+      });
+    }
+  }, [profile, reset]);
+
+  const mutation = useMutation({
+    mutationFn: updateProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+      toast.success('Profile updated successfully');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to update profile');
+    },
+  });
+
+  const onSubmit = (data: ProfileFormData) => {
+    // Send null for empty/null avatarUrl to match API expectations
+    mutation.mutate({
+      ...data,
+      avatarUrl: data.avatarUrl || null,
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-card rounded-xl border p-6">
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="bg-card rounded-xl border p-6">
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <p className="text-destructive text-sm font-medium">Failed to load profile</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            {(error as Error)?.message || 'Please try again later.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-xl border p-6">
+      <h2 className="text-lg font-semibold">Profile</h2>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Update your display name and avatar URL.
+      </p>{' '}
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-5">
+        <div>
+          <label htmlFor="displayName" className="text-sm font-medium">
+            Display Name <span className="text-destructive">*</span>
+          </label>
+          <input
+            id="displayName"
+            type="text"
+            maxLength={50}
+            placeholder="Your display name"
+            className={cn(
+              'bg-background placeholder:text-muted-foreground focus:ring-ring mt-1.5 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2',
+              errors.displayName && 'border-destructive focus:ring-destructive',
+            )}
+            {...register('displayName')}
+          />
+          {errors.displayName && (
+            <p className="text-destructive mt-1 text-xs">{errors.displayName.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="email" className="text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={profile?.email ?? ''}
+            disabled
+            className="bg-muted text-muted-foreground mt-1.5 w-full cursor-not-allowed rounded-lg border px-3 py-2 text-sm"
+          />
+          <p className="text-muted-foreground mt-1 text-xs">Email cannot be changed.</p>
+        </div>
+
+        <div>
+          <label htmlFor="avatarUrl" className="text-sm font-medium">
+            Avatar URL
+          </label>
+          <input
+            id="avatarUrl"
+            type="url"
+            placeholder="https://avatars.githubusercontent.com/u/..."
+            className={cn(
+              'bg-background placeholder:text-muted-foreground focus:ring-ring mt-1.5 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2',
+              errors.avatarUrl && 'border-destructive focus:ring-destructive',
+            )}
+            {...register('avatarUrl')}
+          />
+          {errors.avatarUrl && (
+            <p className="text-destructive mt-1 text-xs">{errors.avatarUrl.message}</p>
+          )}
+          {profile?.avatarUrl && (
+            <div className="mt-2 flex items-center gap-2">
+              <img
+                src={profile.avatarUrl}
+                alt="Avatar preview"
+                className="h-8 w-8 rounded-full object-cover"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = 'none';
+                }}
+              />
+              <span className="text-muted-foreground text-xs">Current avatar preview</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 pt-1">
+          <button
+            type="submit"
+            disabled={!isDirty || mutation.isPending}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50"
+          >
+            {mutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" />
+                Save Changes
+              </>
+            )}
+          </button>
+          {isDirty && (
+            <button
+              type="button"
+              onClick={() => reset()}
+              className="hover:bg-muted inline-flex items-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/profile-form.tsx
+++ b/apps/web/src/components/settings/profile-form.tsx
@@ -2,13 +2,13 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { User } from '@veridion/sdk';
 import { Loader2, Save } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import type { User } from '@veridion/sdk';
 import { cn } from '@/lib/utils';
 
 const profileSchema = z.object({
@@ -26,7 +26,7 @@ async function fetchProfile(): Promise<User> {
     credentials: 'include',
   });
   if (!res.ok) throw new Error('Failed to fetch profile');
-  return res.json();
+  return res.json() as Promise<User>;
 }
 
 async function updateProfile(data: ProfileFormData): Promise<User> {
@@ -37,7 +37,7 @@ async function updateProfile(data: ProfileFormData): Promise<User> {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Failed to update profile');
-  return res.json();
+  return res.json() as Promise<User>;
 }
 
 export function ProfileForm() {
@@ -78,7 +78,7 @@ export function ProfileForm() {
   const mutation = useMutation({
     mutationFn: updateProfile,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['profile'] });
+      void queryClient.invalidateQueries({ queryKey: ['profile'] });
       toast.success('Profile updated successfully');
     },
     onError: (err: Error) => {
@@ -110,7 +110,7 @@ export function ProfileForm() {
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <p className="text-destructive text-sm font-medium">Failed to load profile</p>
           <p className="text-muted-foreground mt-1 text-sm">
-            {(error as Error)?.message || 'Please try again later.'}
+            {error?.message || 'Please try again later.'}
           </p>
         </div>
       </div>
@@ -123,7 +123,12 @@ export function ProfileForm() {
       <p className="text-muted-foreground mt-1 text-sm">
         Update your display name and avatar URL.
       </p>{' '}
-      <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-5">
+      <form
+        onSubmit={(e) => {
+          void handleSubmit(onSubmit)(e);
+        }}
+        className="mt-6 space-y-5"
+      >
         <div>
           <label htmlFor="displayName" className="text-sm font-medium">
             Display Name <span className="text-destructive">*</span>

--- a/apps/web/src/components/settings/wallet-section.tsx
+++ b/apps/web/src/components/settings/wallet-section.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, Copy, ExternalLink, Loader2, Wallet } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import type { User } from '@veridion/sdk';
+import { cn } from '@/lib/utils';
+
+// Stellar public key regex pattern (ed25519 seed)
+// Stellar uses base32 encoding: A-Z (excluding 0,1,8,9) and digits 2-7
+const STELLAR_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
+
+async function fetchProfile(): Promise<User> {
+  const res = await fetch('/api/users/me', {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to fetch profile');
+  return res.json();
+}
+
+async function updateWallet(walletAddress: string): Promise<User> {
+  const res = await fetch('/api/users/me', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ walletAddress: walletAddress || null }),
+  });
+  if (!res.ok) throw new Error('Failed to update wallet address');
+  return res.json();
+}
+
+function validateStellarAddress(address: string): string | null {
+  if (!address) return null;
+  const trimmed = address.trim();
+  if (!trimmed) return null;
+  if (!trimmed.startsWith('G')) return 'Stellar address must start with G';
+  if (trimmed.length !== 56) return 'Stellar address must be exactly 56 characters';
+  if (!STELLAR_ADDRESS_REGEX.test(trimmed)) return 'Invalid Stellar address format';
+  return null;
+}
+
+export function WalletSection() {
+  const queryClient = useQueryClient();
+  const [addressInput, setAddressInput] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const { data: profile, isLoading } = useQuery<User>({
+    queryKey: ['profile'],
+    queryFn: fetchProfile,
+  });
+
+  const mutation = useMutation({
+    mutationFn: updateWallet,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+      toast.success('Wallet address updated successfully');
+      setIsEditing(false);
+      setValidationError(null);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to update wallet address');
+    },
+  });
+
+  const walletAddress = profile?.walletAddress ?? null;
+
+  const handleSave = () => {
+    const trimmed = addressInput.trim();
+    const error = validateStellarAddress(trimmed);
+    if (trimmed && error) {
+      setValidationError(error);
+      return;
+    }
+    setValidationError(null);
+    mutation.mutate(trimmed);
+  };
+
+  const handleEdit = () => {
+    setAddressInput(walletAddress ?? '');
+    setIsEditing(true);
+    setValidationError(null);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setAddressInput('');
+    setValidationError(null);
+  };
+
+  const handleCopy = () => {
+    if (walletAddress) {
+      navigator.clipboard.writeText(walletAddress);
+      toast.success('Wallet address copied to clipboard');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-card rounded-xl border p-6">
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-xl border p-6">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
+            <Wallet className="text-primary h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold">Wallet Address</h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Connect your Stellar wallet to verify audits on-chain.
+            </p>
+          </div>
+        </div>
+        {walletAddress && !isEditing && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-500">
+            <CheckCircle2 className="h-3 w-3" />
+            Connected
+          </span>
+        )}
+      </div>
+
+      {isEditing ? (
+        <div className="mt-5 space-y-4">
+          <div>
+            <label htmlFor="walletAddress" className="text-sm font-medium">
+              Stellar Public Key
+            </label>
+            <input
+              id="walletAddress"
+              type="text"
+              value={addressInput}
+              onChange={(e) => {
+                setAddressInput(e.target.value);
+                setValidationError(null);
+              }}
+              placeholder="G..."
+              maxLength={56}
+              autoFocus
+              className={cn(
+                'bg-background placeholder:text-muted-foreground focus:ring-ring mt-1.5 w-full rounded-lg border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2',
+                validationError && 'border-destructive focus:ring-destructive',
+              )}
+            />
+            {validationError && <p className="text-destructive mt-1 text-xs">{validationError}</p>}
+            <p className="text-muted-foreground mt-1 text-xs">
+              Enter your Stellar public key (starts with G, 56 characters).
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleSave}
+              disabled={mutation.isPending}
+              className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50"
+            >
+              {mutation.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="h-4 w-4" />
+                  Save Address
+                </>
+              )}
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={mutation.isPending}
+              className="hover:bg-muted inline-flex items-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5">
+          {walletAddress ? (
+            <div className="space-y-4">
+              <div className="bg-background flex items-center justify-between rounded-lg border p-3">
+                <code className="font-mono text-sm">{walletAddress}</code>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={handleCopy}
+                    className="text-muted-foreground hover:text-foreground rounded-md p-1.5 transition-colors"
+                    title="Copy address"
+                  >
+                    <Copy className="h-4 w-4" />
+                  </button>
+                  <a
+                    href={`https://stellar.expert/explorer/public/account/${walletAddress}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground rounded-md p-1.5 transition-colors"
+                    title="View on Stellar Expert"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                </div>
+              </div>
+              <button
+                onClick={handleEdit}
+                className="text-primary text-sm font-medium hover:underline"
+              >
+                Change wallet address
+              </button>
+            </div>
+          ) : (
+            <div className="mt-4">
+              <button
+                onClick={handleEdit}
+                className="hover:bg-muted inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+              >
+                <Wallet className="h-4 w-4" />
+                Connect Stellar Wallet
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/wallet-section.tsx
+++ b/apps/web/src/components/settings/wallet-section.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { User } from '@veridion/sdk';
 import { CheckCircle2, Copy, ExternalLink, Loader2, Wallet } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import type { User } from '@veridion/sdk';
 import { cn } from '@/lib/utils';
 
 // Stellar public key regex pattern (ed25519 seed)
@@ -17,7 +17,7 @@ async function fetchProfile(): Promise<User> {
     credentials: 'include',
   });
   if (!res.ok) throw new Error('Failed to fetch profile');
-  return res.json();
+  return res.json() as Promise<User>;
 }
 
 async function updateWallet(walletAddress: string): Promise<User> {
@@ -28,7 +28,7 @@ async function updateWallet(walletAddress: string): Promise<User> {
     body: JSON.stringify({ walletAddress: walletAddress || null }),
   });
   if (!res.ok) throw new Error('Failed to update wallet address');
-  return res.json();
+  return res.json() as Promise<User>;
 }
 
 function validateStellarAddress(address: string): string | null {
@@ -55,7 +55,7 @@ export function WalletSection() {
   const mutation = useMutation({
     mutationFn: updateWallet,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['profile'] });
+      void queryClient.invalidateQueries({ queryKey: ['profile'] });
       toast.success('Wallet address updated successfully');
       setIsEditing(false);
       setValidationError(null);
@@ -92,7 +92,7 @@ export function WalletSection() {
 
   const handleCopy = () => {
     if (walletAddress) {
-      navigator.clipboard.writeText(walletAddress);
+      void navigator.clipboard.writeText(walletAddress);
       toast.success('Wallet address copied to clipboard');
     }
   };


### PR DESCRIPTION
## Summary

Fixes all CI lint errors that were failing on PR #60. closes #37 

## Changes

### `apps/api/src/modules/api-keys/dto/api-key.dto.ts`
- Remove unused `IsOptional` import (the only lint error in the API package)

### `apps/web/src/components/settings/api-keys-list.tsx`
- Remove stale `updatedAt` from `ApiKey` interface (API no longer returns it)
- Add `as Promise<T>` type assertions to `res.json()` fetch returns
- Add `void` operator to floating promises (`invalidateQueries`, `clipboard.writeText`, `refetch`)
- Remove unnecessary `error as Error` type assertion (`useQuery` already types `error`)

### `apps/web/src/components/settings/profile-form.tsx`
- Fix `simple-import-sort` ordering: `@veridion/sdk` before `lucide-react` (`@` sorts before lowercase)
- Add `as Promise<User>` type assertions
- Add `void` operator to floating promises
- Wrap `handleSubmit(onSubmit)` in void arrow to fix `no-misused-promises`
- Remove unnecessary `error as Error` assertion

### `apps/web/src/components/settings/wallet-section.tsx`
- Fix `simple-import-sort` ordering
- Add `as Promise<User>` type assertions
- Add `void` operator to floating promises (`invalidateQueries`, `clipboard.writeText`)

## Verification

All 5 CI stages pass locally:
- ✅ `pnpm format:check`
- ✅ `pnpm lint` (16 tasks)
- ✅ `pnpm typecheck` (30 tasks)
- ✅ `pnpm test` (39 suites)
- ✅ `pnpm build` (20 tasks)