### PR TITLE
feat(api): add resilient Redis caching layer

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ThrottlerModule } from '@nestjs/throttler';
 
+import { CacheModule } from './common/cache/cache.module';
 import { PrismaModule } from './common/prisma/prisma.module';
 import { AiModule } from './modules/ai/ai.module';
 import { ApiKeysModule } from './modules/api-keys/api-keys.module';
@@ -27,6 +28,7 @@ import { UsersModule } from './modules/users/users.module';
         },
       }),
     }),
+    CacheModule,
     PrismaModule,
     HealthModule,
     AuthModule,

--- a/apps/api/src/common/cache/cache.constants.ts
+++ b/apps/api/src/common/cache/cache.constants.ts
@@ -1,0 +1,9 @@
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+export const CACHE_TTL_CONFIG = Symbol('CACHE_TTL_CONFIG');
+
+export interface CacheTtlConfig {
+  projects: number;
+  audits: number;
+  profiles: number;
+  plugins: number;
+}

--- a/apps/api/src/common/cache/cache.module.ts
+++ b/apps/api/src/common/cache/cache.module.ts
@@ -1,0 +1,64 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { logger } from '@veridion/logger';
+import Redis from 'ioredis';
+
+import { CACHE_TTL_CONFIG, type CacheTtlConfig, REDIS_CLIENT } from './cache.constants';
+import { CacheService } from './cache.service';
+
+function createRedisClient(config: ConfigService): Redis {
+  const redisUrl = config.get<string>('REDIS_URL');
+  const options = {
+    enableOfflineQueue: false,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    retryStrategy: (attempt: number) => (attempt > 1 ? null : 100),
+  };
+  const client = redisUrl
+    ? new Redis(redisUrl, options)
+    : new Redis({
+        host: config.get<string>('REDIS_HOST', 'localhost'),
+        port: Number(config.get<string | number>('REDIS_PORT', 6379)),
+        ...options,
+      });
+
+  client.on('error', (error) => {
+    logger.warn({ error }, 'Redis unavailable; cache requests will fall back to the database');
+  });
+
+  return client;
+}
+
+function createTtlConfig(config: ConfigService): CacheTtlConfig {
+  const ttl = (name: string, fallback: number) => {
+    const value = Number(config.get<string | number>(name, fallback));
+    return Number.isFinite(value) && value > 0 ? value : fallback;
+  };
+
+  return {
+    projects: ttl('CACHE_PROJECT_TTL', 60),
+    audits: ttl('CACHE_AUDIT_TTL', 60),
+    profiles: ttl('CACHE_PROFILE_TTL', 300),
+    plugins: ttl('CACHE_PLUGIN_TTL', 300),
+  };
+}
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      inject: [ConfigService],
+      useFactory: createRedisClient,
+    },
+    {
+      provide: CACHE_TTL_CONFIG,
+      inject: [ConfigService],
+      useFactory: createTtlConfig,
+    },
+    CacheService,
+  ],
+  exports: [CacheService],
+})
+export class CacheModule {}

--- a/apps/api/src/common/cache/cache.service.spec.ts
+++ b/apps/api/src/common/cache/cache.service.spec.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import type { CacheClient } from './cache.service';
+import { CacheService } from './cache.service';
+
+function createClient(): jest.Mocked<CacheClient> {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    scan: jest.fn(),
+    quit: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+describe('CacheService', () => {
+  let client: jest.Mocked<CacheClient>;
+  let service: CacheService;
+
+  beforeEach(() => {
+    client = createClient();
+    service = new CacheService(client, {
+      projects: 60,
+      audits: 120,
+      profiles: 300,
+      plugins: 600,
+    });
+  });
+
+  it('returns parsed values on cache hits', async () => {
+    client.get.mockResolvedValue(JSON.stringify({ total: 2 }));
+
+    await expect(service.get<{ total: number }>('projects:user:1')).resolves.toEqual({ total: 2 });
+  });
+
+  it('returns null when the cache misses', async () => {
+    client.get.mockResolvedValue(null);
+
+    await expect(service.get('missing')).resolves.toBeNull();
+  });
+
+  it('falls back when Redis is unavailable', async () => {
+    client.get.mockRejectedValue(new Error('connection refused'));
+
+    await expect(service.get('unavailable')).resolves.toBeNull();
+    await expect(
+      service.getOrSet('unavailable', async () => ({ value: 'database' })),
+    ).resolves.toEqual({
+      value: 'database',
+    });
+  });
+
+  it('serializes values and applies the configured TTL', async () => {
+    client.set.mockResolvedValue('OK');
+
+    await service.set('projects:user:1', { total: 2 }, service.getTtl('projects'));
+
+    expect(client.set).toHaveBeenCalledWith(
+      'projects:user:1',
+      JSON.stringify({ total: 2 }),
+      'EX',
+      60,
+    );
+  });
+
+  it('invalidates every key matching a prefix with SCAN', async () => {
+    client.scan
+      .mockResolvedValueOnce(['1', ['projects:user:1:1', 'projects:user:1:2']])
+      .mockResolvedValueOnce(['0', ['projects:user:1:3']]);
+    client.del.mockResolvedValue(1);
+
+    await service.invalidateByPrefix('projects:user:1:');
+
+    expect(client.scan).toHaveBeenNthCalledWith(
+      1,
+      '0',
+      'MATCH',
+      'projects:user:1:*',
+      'COUNT',
+      '100',
+    );
+    expect(client.del).toHaveBeenCalledWith('projects:user:1:1', 'projects:user:1:2');
+    expect(client.del).toHaveBeenCalledWith('projects:user:1:3');
+  });
+});

--- a/apps/api/src/common/cache/cache.service.ts
+++ b/apps/api/src/common/cache/cache.service.ts
@@ -1,0 +1,97 @@
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { logger } from '@veridion/logger';
+
+import { CACHE_TTL_CONFIG, type CacheTtlConfig, REDIS_CLIENT } from './cache.constants';
+
+export interface CacheClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode: 'EX', ttl: number): Promise<unknown>;
+  del(...keys: string[]): Promise<number>;
+  scan(cursor: string, ...args: string[]): Promise<[string, string[]]>;
+  quit(): Promise<unknown>;
+  disconnect(): void;
+}
+
+@Injectable()
+export class CacheService implements OnModuleDestroy {
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly client: CacheClient,
+    @Inject(CACHE_TTL_CONFIG) private readonly ttlConfig: CacheTtlConfig,
+  ) {}
+
+  getTtl(entity: keyof CacheTtlConfig): number {
+    return this.ttlConfig[entity];
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const value = await this.client.get(key);
+      if (value === null) {
+        logger.debug({ key }, 'Cache miss');
+        return null;
+      }
+
+      logger.debug({ key }, 'Cache hit');
+      return JSON.parse(value) as T;
+    } catch (error) {
+      logger.warn({ key, error }, 'Cache read failed; using database result');
+      return null;
+    }
+  }
+
+  async set<T>(key: string, value: T, ttl = this.ttlConfig.projects): Promise<void> {
+    try {
+      await this.client.set(key, JSON.stringify(value), 'EX', ttl);
+    } catch (error) {
+      logger.warn({ key, error }, 'Cache write failed; continuing without cache');
+    }
+  }
+
+  async getOrSet<T>(
+    key: string,
+    factory: () => Promise<T>,
+    ttl = this.ttlConfig.projects,
+  ): Promise<T> {
+    const cached = await this.get<T>(key);
+    if (cached !== null) return cached;
+
+    const value = await factory();
+    await this.set(key, value, ttl);
+    return value;
+  }
+
+  async invalidate(key: string): Promise<void> {
+    try {
+      await this.client.del(key);
+    } catch (error) {
+      logger.warn({ key, error }, 'Cache invalidation failed');
+    }
+  }
+
+  async invalidateByPrefix(prefix: string): Promise<void> {
+    try {
+      let cursor = '0';
+      do {
+        const [nextCursor, keys] = await this.client.scan(
+          cursor,
+          'MATCH',
+          `${prefix}*`,
+          'COUNT',
+          '100',
+        );
+        if (keys.length > 0) await this.client.del(...keys);
+        cursor = nextCursor;
+      } while (cursor !== '0');
+    } catch (error) {
+      logger.warn({ prefix, error }, 'Cache prefix invalidation failed');
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    try {
+      await this.client.quit();
+    } catch {
+      this.client.disconnect();
+    }
+  }
+}

--- a/apps/api/src/modules/audits/audits.service.ts
+++ b/apps/api/src/modules/audits/audits.service.ts
@@ -1,12 +1,28 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { logger } from '@veridion/logger';
 
+import { CacheService } from '../../common/cache/cache.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import type { AuditQueryDto, CreateAuditDto } from './dto/audit.dto';
 
+type AuditListResult = {
+  data: unknown[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+};
+
 @Injectable()
 export class AuditsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: CacheService,
+  ) {}
 
   async create(userId: string, dto: CreateAuditDto) {
     const project = await this.prisma.db.project.findUnique({ where: { id: dto.projectId } });
@@ -21,13 +37,19 @@ export class AuditsService {
       },
     });
 
+    await this.cache.invalidateByPrefix(this.auditCachePrefix(userId));
+    await this.cache.invalidate(`project:${userId}:${dto.projectId}`);
     logger.info({ auditId: audit.id, projectId: dto.projectId }, 'Audit created');
 
     return audit;
   }
 
-  async findAll(userId: string, query: AuditQueryDto) {
+  async findAll(userId: string, query: AuditQueryDto): Promise<AuditListResult> {
     const { page = 1, limit = 20, status, projectId } = query;
+    const cacheKey = `${this.auditCachePrefix(userId)}${page}:${limit}:${status ?? ''}:${projectId ?? ''}`;
+    const cached = await this.cache.get<unknown>(cacheKey);
+    if (cached !== null) return cached as AuditListResult;
+
     const where = {
       project: { userId },
       ...(status ? { status } : {}),
@@ -45,7 +67,7 @@ export class AuditsService {
       this.prisma.db.audit.count({ where }),
     ]);
 
-    return {
+    const result = {
       data,
       meta: {
         total,
@@ -56,9 +78,16 @@ export class AuditsService {
         hasPreviousPage: page > 1,
       },
     };
+
+    await this.cache.set(cacheKey, result, this.cache.getTtl('audits'));
+    return result;
   }
 
-  async findOne(id: string, userId: string) {
+  async findOne(id: string, userId: string): Promise<unknown> {
+    const cacheKey = `audit:${userId}:${id}`;
+    const cached = await this.cache.get<unknown>(cacheKey);
+    if (cached !== null) return cached;
+
     const audit = await this.prisma.db.audit.findUnique({
       where: { id },
       include: {
@@ -70,6 +99,11 @@ export class AuditsService {
     if (!audit) throw new NotFoundException('Audit not found');
     if (audit.project.userId !== userId) throw new ForbiddenException('Access denied');
 
+    await this.cache.set(cacheKey, audit, this.cache.getTtl('audits'));
     return audit;
+  }
+
+  private auditCachePrefix(userId: string): string {
+    return `audits:${userId}:`;
   }
 }

--- a/apps/api/src/modules/projects/projects.service.ts
+++ b/apps/api/src/modules/projects/projects.service.ts
@@ -1,14 +1,30 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 
+import { CacheService } from '../../common/cache/cache.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import type { CreateProjectDto, ProjectQueryDto, UpdateProjectDto } from './dto/project.dto';
 
+type ProjectListResult = {
+  data: unknown[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+};
+
 @Injectable()
 export class ProjectsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: CacheService,
+  ) {}
 
   async create(userId: string, dto: CreateProjectDto) {
-    return this.prisma.db.project.create({
+    const project = await this.prisma.db.project.create({
       data: {
         name: dto.name,
         description: dto.description ?? null,
@@ -19,10 +35,17 @@ export class ProjectsService {
         organizationId: dto.organizationId ?? null,
       },
     });
+
+    await this.cache.invalidateByPrefix(this.projectCachePrefix(userId));
+    return project;
   }
 
-  async findAll(userId: string, query: ProjectQueryDto) {
+  async findAll(userId: string, query: ProjectQueryDto): Promise<ProjectListResult> {
     const { page = 1, limit = 20, search } = query;
+    const cacheKey = `${this.projectCachePrefix(userId)}${page}:${limit}:${search ?? ''}`;
+    const cached = await this.cache.get<unknown>(cacheKey);
+    if (cached !== null) return cached as ProjectListResult;
+
     const where = {
       userId,
       ...(search ? { name: { contains: search, mode: 'insensitive' as const } } : {}),
@@ -39,7 +62,7 @@ export class ProjectsService {
       this.prisma.db.project.count({ where }),
     ]);
 
-    return {
+    const result = {
       data,
       meta: {
         total,
@@ -50,9 +73,16 @@ export class ProjectsService {
         hasPreviousPage: page > 1,
       },
     };
+
+    await this.cache.set(cacheKey, result, this.cache.getTtl('projects'));
+    return result;
   }
 
-  async findOne(id: string, userId: string) {
+  async findOne(id: string, userId: string): Promise<unknown> {
+    const cacheKey = `project:${userId}:${id}`;
+    const cached = await this.cache.get<unknown>(cacheKey);
+    if (cached !== null) return cached;
+
     const project = await this.prisma.db.project.findUnique({
       where: { id },
       include: { _count: { select: { audits: true, contracts: true } } },
@@ -61,21 +91,32 @@ export class ProjectsService {
     if (!project) throw new NotFoundException('Project not found');
     if (project.userId !== userId) throw new ForbiddenException('Access denied');
 
+    await this.cache.set(cacheKey, project, this.cache.getTtl('projects'));
     return project;
   }
 
   async update(id: string, userId: string, dto: UpdateProjectDto) {
     await this.findOne(id, userId);
 
-    return this.prisma.db.project.update({
+    const project = await this.prisma.db.project.update({
       where: { id },
       data: dto,
     });
+
+    await this.cache.invalidate(`project:${userId}:${id}`);
+    await this.cache.invalidateByPrefix(this.projectCachePrefix(userId));
+    return project;
   }
 
   async remove(id: string, userId: string) {
     await this.findOne(id, userId);
     await this.prisma.db.project.delete({ where: { id } });
+    await this.cache.invalidate(`project:${userId}:${id}`);
+    await this.cache.invalidateByPrefix(this.projectCachePrefix(userId));
     return { message: 'Project deleted' };
+  }
+
+  private projectCachePrefix(userId: string): string {
+    return `projects:${userId}:`;
   }
 }


### PR DESCRIPTION
Closes #39

## Summary
- add a global Redis cache module and wrapper service with JSON serialization, TTL configuration, hit/miss logging, and graceful fallback
- cache project and audit list/detail reads with invalidation after writes
- configure Redis URL/host/port and per-entity TTLs through environment variables
- add mocked Redis unit coverage for hits, misses, failures, TTLs, and prefix invalidation

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build