### PR TITLE
feat(web): implement report generation and history

### DIFF
--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -13,6 +13,12 @@ import { ReportsService } from './reports.service';
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
+  @Get()
+  @ApiOperation({ summary: 'List generated reports for the current user' })
+  list(@CurrentUser('id') userId: string) {
+    return this.reportsService.list(userId);
+  }
+
   @Post('generate')
   @ApiOperation({ summary: 'Generate audit report' })
   generate(@Body() dto: GenerateReportDto, @CurrentUser('id') userId: string) {

--- a/apps/api/src/modules/reports/reports.service.spec.ts
+++ b/apps/api/src/modules/reports/reports.service.spec.ts
@@ -1,0 +1,105 @@
+import { ForbiddenException } from '@nestjs/common';
+
+import { ReportsService } from './reports.service';
+
+function createPrisma() {
+  return {
+    db: {
+      audit: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+      },
+    },
+  };
+}
+
+const audit = {
+  id: 'audit-id',
+  project: {
+    name: 'Example Protocol',
+    userId: 'user-id',
+    chain: 'ethereum',
+    language: 'solidity',
+    contracts: [{ name: 'Example.sol', hash: 'contract-hash' }],
+  },
+  commitHash: 'commit-hash',
+  securityScore: 91,
+  reportHash: null,
+  completedAt: new Date('2026-08-12T12:00:00.000Z'),
+  findings: [
+    {
+      id: 'finding-id',
+      auditId: 'audit-id',
+      pluginId: 'reentrancy',
+      title: 'Reentrancy risk',
+      description: 'An external call occurs before state changes.',
+      severity: 'HIGH',
+      filePath: 'Example.sol',
+      lineStart: 10,
+      lineEnd: 14,
+      codeSnippet: 'withdraw();',
+      recommendation: 'Use checks-effects-interactions.',
+      aiSummary: 'The state update should happen before the external call.',
+      confidence: 0.95,
+      references: [],
+      status: 'OPEN',
+      assignedToId: null,
+      createdAt: new Date('2026-08-12T12:00:00.000Z'),
+      updatedAt: new Date('2026-08-12T12:00:00.000Z'),
+    },
+  ],
+};
+
+describe('ReportsService', () => {
+  const prisma = createPrisma();
+  let service: ReportsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ReportsService(prisma as never);
+    prisma.db.audit.findUnique.mockResolvedValue(audit);
+    prisma.db.audit.update.mockResolvedValue({});
+  });
+
+  it('generates JSON through the shared formatter and can omit AI summaries', async () => {
+    const result = await service.generate('user-id', {
+      auditId: 'audit-id',
+      format: 'JSON',
+      includeAiSummary: false,
+    });
+
+    const content = JSON.parse(result.content) as {
+      findings: Array<{ aiSummary?: string | null }>;
+    };
+    expect(result.contentType).toBe('application/json');
+    expect(result.fileExtension).toBe('json');
+    expect(content.findings[0]?.aiSummary).toBeNull();
+    expect(prisma.db.audit.update).toHaveBeenCalledWith({
+      where: { id: 'audit-id' },
+      data: { reportHash: 'report-audit-id' },
+    });
+  });
+
+  it('prevents users from generating reports for another user', async () => {
+    await expect(
+      service.generate('another-user', {
+        auditId: 'audit-id',
+        format: 'MARKDOWN',
+        includeAiSummary: true,
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.db.audit.update).not.toHaveBeenCalled();
+  });
+
+  it('scopes history to the current user', async () => {
+    prisma.db.audit.findMany.mockResolvedValue([]);
+
+    await expect(service.list('user-id')).resolves.toEqual([]);
+    expect(prisma.db.audit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { project: { userId: 'user-id' }, reportHash: { not: null } },
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -1,5 +1,13 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { logger } from '@veridion/logger';
+import {
+  HtmlFormatter,
+  JsonFormatter,
+  MarkdownFormatter,
+  type ReportData,
+  ReportGenerator,
+} from '@veridion/report-generator';
+import { ReportFormat } from '@veridion/shared';
 
 import { PrismaService } from '../../common/prisma/prisma.service';
 import type { GenerateReportDto } from './dto/report.dto';
@@ -9,57 +17,84 @@ export class ReportsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async generate(userId: string, dto: GenerateReportDto) {
-    const audit = await this.prisma.db.audit.findUnique({
-      where: { id: dto.auditId },
-      include: {
-        project: { select: { name: true, userId: true } },
-        findings: { orderBy: { severity: 'asc' } },
-      },
-    });
-
+    const audit = await prismaAuditWithReportData(this.prisma, dto.auditId);
     if (!audit) throw new NotFoundException('Audit not found');
     if (audit.project.userId !== userId) throw new ForbiddenException('Access denied');
 
-    logger.info({ auditId: dto.auditId, format: dto.format }, 'Generating report');
-
-    const report = {
+    const format = dto.format as ReportFormat;
+    const generatedAt = new Date();
+    const reportData = {
       auditId: audit.id,
       projectName: audit.project.name,
+      contractName: audit.project.contracts[0]?.name ?? audit.project.name,
+      contractHash: audit.project.contracts[0]?.hash ?? audit.commitHash ?? audit.id,
+      chain: audit.project.chain,
+      language: audit.project.language,
       securityScore: audit.securityScore ?? 0,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      findings: audit.findings.map((f: any) => ({
-        id: f.id,
-        title: f.title,
-        description: f.description,
-        severity: f.severity,
-        filePath: f.filePath,
-        lineStart: f.lineStart,
-        lineEnd: f.lineEnd,
-        codeSnippet: f.codeSnippet,
-        recommendation: f.recommendation,
-        aiSummary: f.aiSummary,
-      })),
-      format: dto.format,
-      generatedAt: new Date().toISOString(),
+      findings: audit.findings.map((finding) => ({
+        ...finding,
+        aiSummary: dto.includeAiSummary ? finding.aiSummary : null,
+      })) as unknown as ReportData['findings'],
+      generatedAt,
+      version: '1.0.0',
     };
+
+    const generator = new ReportGenerator();
+    generator.registerFormatter(new JsonFormatter());
+    generator.registerFormatter(new MarkdownFormatter());
+    generator.registerFormatter(new HtmlFormatter());
+    generator.registerFormatter({
+      format: ReportFormat.PDF,
+      generate: () => 'PDF generation is not available yet. Download the HTML report instead.',
+    });
+
+    logger.info({ auditId: dto.auditId, format }, 'Generating report');
+    const content = generator.generate(reportData, format);
+    const reportHash = `report-${audit.id}`;
 
     await this.prisma.db.audit.update({
       where: { id: dto.auditId },
-      data: { reportHash: `report-${dto.auditId}` },
+      data: { reportHash },
     });
 
-    return report;
+    return {
+      auditId: audit.id,
+      projectName: audit.project.name,
+      format,
+      content,
+      contentType: this.getContentType(format),
+      fileExtension: this.getFileExtension(format),
+      reportHash,
+      generatedAt: generatedAt.toISOString(),
+    };
   }
 
-  async getReport(auditId: string, userId: string) {
-    const audit = await this.prisma.db.audit.findUnique({
-      where: { id: auditId },
+  async list(userId: string) {
+    const audits = await this.prisma.db.audit.findMany({
+      where: { project: { userId }, reportHash: { not: null } },
+      orderBy: { updatedAt: 'desc' },
       include: {
-        project: { select: { name: true, userId: true } },
-        findings: true,
+        project: { select: { name: true } },
+        _count: { select: { findings: true } },
       },
     });
 
+    return audits.map((audit) => ({
+      id: audit.id,
+      auditId: audit.id,
+      projectName: audit.project.name,
+      auditDate: audit.createdAt,
+      securityScore: audit.securityScore,
+      findings: audit._count.findings,
+      status: audit.status,
+      generatedAt: audit.updatedAt,
+      reportHash: audit.reportHash,
+      formats: [ReportFormat.JSON, ReportFormat.MARKDOWN, ReportFormat.HTML, ReportFormat.PDF],
+    }));
+  }
+
+  async getReport(auditId: string, userId: string) {
+    const audit = await prismaAuditWithReportData(this.prisma, auditId);
     if (!audit) throw new NotFoundException('Audit not found');
     if (audit.project.userId !== userId) throw new ForbiddenException('Access denied');
 
@@ -72,4 +107,46 @@ export class ReportsService {
       generatedAt: audit.completedAt,
     };
   }
+
+  private getContentType(format: ReportFormat): string {
+    switch (format) {
+      case ReportFormat.HTML:
+        return 'text/html';
+      case ReportFormat.JSON:
+        return 'application/json';
+      case ReportFormat.PDF:
+        return 'text/plain';
+      case ReportFormat.MARKDOWN:
+      default:
+        return 'text/markdown';
+    }
+  }
+
+  private getFileExtension(format: ReportFormat): string {
+    if (format === ReportFormat.MARKDOWN) return 'md';
+    if (format === ReportFormat.PDF) return 'txt';
+    return format.toLowerCase();
+  }
+}
+
+function prismaAuditWithReportData(prisma: PrismaService, auditId: string) {
+  return prisma.db.audit.findUnique({
+    where: { id: auditId },
+    include: {
+      project: {
+        select: {
+          name: true,
+          userId: true,
+          chain: true,
+          language: true,
+          contracts: {
+            take: 1,
+            orderBy: { createdAt: 'asc' },
+            select: { name: true, hash: true },
+          },
+        },
+      },
+      findings: { orderBy: { severity: 'asc' } },
+    },
+  });
 }

--- a/apps/web/src/app/dashboard/reports/page.tsx
+++ b/apps/web/src/app/dashboard/reports/page.tsx
@@ -1,219 +1,214 @@
 'use client';
 
-import {
-  Calendar,
-  CheckCircle2,
-  ChevronDown,
-  Clock,
-  Eye,
-  FileJson,
-  FileText,
-  Share2,
-  Shield,
-} from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Calendar, ChevronDown, Clock3, FileText, RefreshCw, ShieldCheck } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-const reports = [
-  {
-    id: 'r1',
-    auditId: 'a1',
-    projectName: 'DeFi Protocol v2',
-    auditDate: '2024-06-15',
-    securityScore: 82,
-    findings: 14,
-    status: 'COMPLETED',
-    formats: ['PDF', 'MARKDOWN', 'HTML', 'JSON'],
-    generatedAt: '2024-06-15 10:35',
-    reportHash: 'report-a1',
-  },
-  {
-    id: 'r2',
-    auditId: 'a2',
-    projectName: 'Staking Rewards',
-    auditDate: '2024-06-01',
-    securityScore: 93,
-    findings: 3,
-    status: 'VERIFIED',
-    formats: ['PDF', 'MARKDOWN', 'HTML', 'JSON'],
-    generatedAt: '2024-06-01 14:20',
-    reportHash: 'report-a2',
-  },
-  {
-    id: 'r3',
-    auditId: 'a3',
-    projectName: 'NFT Marketplace',
-    auditDate: '2024-05-28',
-    securityScore: 78,
-    findings: 8,
-    status: 'COMPLETED',
-    formats: ['MARKDOWN', 'JSON'],
-    generatedAt: '2024-05-28 11:15',
-    reportHash: 'report-a3',
-  },
-  {
-    id: 'r4',
-    auditId: 'a4',
-    projectName: 'Token Vesting',
-    auditDate: '2024-05-20',
-    securityScore: null,
-    findings: null,
-    status: 'FAILED',
-    formats: [],
-    generatedAt: null,
-    reportHash: null,
-  },
-];
+import { ReportGeneratorForm } from '@/components/reports/report-generator';
+import { ReportPreview } from '@/components/reports/report-preview';
+import {
+  fetchAudits,
+  fetchReports,
+  type GeneratedReport,
+  generateReport,
+  type ReportFormat,
+  type ReportHistoryItem,
+} from '@/lib/api-client';
 
-const formatIcons: Record<string, React.ElementType> = {
-  PDF: FileText,
-  MARKDOWN: FileText,
-  HTML: FileJson,
-  JSON: FileJson,
-};
-
-const statusBadge: Record<string, { icon: React.ElementType; color: string }> = {
-  COMPLETED: { icon: CheckCircle2, color: 'text-emerald-500' },
-  VERIFIED: { icon: Shield, color: 'text-violet-500' },
-  FAILED: { icon: Clock, color: 'text-red-500' },
+const statusColors: Record<string, string> = {
+  COMPLETED: 'text-emerald-500',
+  VERIFIED: 'text-violet-500',
+  FAILED: 'text-red-500',
+  SCANNING: 'text-blue-500',
+  PENDING: 'text-amber-500',
 };
 
 export default function ReportsPage() {
+  const queryClient = useQueryClient();
+  const [preview, setPreview] = useState<GeneratedReport | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const auditsQuery = useQuery({ queryKey: ['report-audits'], queryFn: fetchAudits });
+  const reportsQuery = useQuery({ queryKey: ['reports'], queryFn: fetchReports });
+  const generateMutation = useMutation({
+    mutationFn: ({
+      auditId,
+      format,
+      includeAiSummary,
+    }: {
+      auditId: string;
+      format: ReportFormat;
+      includeAiSummary: boolean;
+    }) => generateReport(auditId, format, includeAiSummary),
+    onSuccess: (report) => {
+      setPreview(report);
+      toast.success(`${report.format} report generated`);
+      void queryClient.invalidateQueries({ queryKey: ['reports'] });
+    },
+  });
 
-  function handleDownload(_reportId: string, format: string) {
-    // TODO: Replace with actual download
-    toast.success(`Downloading ${format} report...`);
+  function handleGenerate(auditId: string, format: ReportFormat, includeAiSummary: boolean) {
+    generateMutation.mutate({ auditId, format, includeAiSummary });
   }
 
-  function handleShare(_reportId: string) {
-    toast.info('Report link copied to clipboard!');
+  function generateHistoryReport(report: ReportHistoryItem, format: ReportFormat) {
+    generateMutation.mutate({ auditId: report.auditId, format, includeAiSummary: true });
   }
+
+  const history = reportsQuery.data ?? [];
+  const error = auditsQuery.error ?? reportsQuery.error ?? generateMutation.error;
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">Reports</h1>
-        <p className="text-muted-foreground mt-1">View and download generated audit reports.</p>
+        <p className="text-primary text-sm font-semibold uppercase tracking-wider">
+          Security center
+        </p>
+        <h1 className="mt-1 text-3xl font-bold tracking-tight">Reports</h1>
+        <p className="text-muted-foreground mt-1">
+          Generate, preview, and download audit reports in the format your team needs.
+        </p>
       </div>
 
-      <div className="bg-card rounded-xl border">
-        <div className="divide-y">
-          {reports.map((report) => {
-            const isExpanded = expandedId === report.id;
-            const badge = statusBadge[report.status];
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+        <ReportGeneratorForm
+          audits={auditsQuery.data?.data ?? []}
+          isLoading={generateMutation.isPending || auditsQuery.isLoading}
+          error={error instanceof Error ? error.message : null}
+          onGenerate={handleGenerate}
+        />
+        {preview ? (
+          <ReportPreview report={preview} />
+        ) : (
+          <div className="bg-card flex min-h-[28rem] flex-col items-center justify-center rounded-xl border px-8 text-center shadow-sm">
+            <div className="bg-primary/10 text-primary flex h-14 w-14 items-center justify-center rounded-2xl">
+              <FileText className="h-7 w-7" />
+            </div>
+            <h2 className="mt-4 text-lg font-semibold">Your preview will appear here</h2>
+            <p className="text-muted-foreground mt-1 max-w-sm text-sm">
+              Select an audit and format to inspect the generated report before downloading it.
+            </p>
+          </div>
+        )}
+      </div>
 
-            return (
-              <div key={report.id} className="hover:bg-muted/20 transition-colors">
-                <div
-                  className="flex cursor-pointer items-center justify-between px-6 py-4"
-                  onClick={() => setExpandedId(isExpanded ? null : report.id)}
-                >
-                  <div className="flex items-center gap-4">
-                    <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-                      <FileText className="text-primary h-5 w-5" />
-                    </div>
-                    <div>
-                      <p className="font-medium">{report.projectName}</p>
-                      <div className="text-muted-foreground flex items-center gap-3 text-sm">
-                        <span className="inline-flex items-center gap-1">
-                          <Calendar className="h-3.5 w-3.5" />
-                          {report.auditDate}
-                        </span>
-                        {report.securityScore != null && (
-                          <span>Score: {report.securityScore}/100</span>
-                        )}
-                        {report.findings != null && <span>{report.findings} findings</span>}
-                      </div>
-                    </div>
-                  </div>
+      <section className="bg-card rounded-xl border shadow-sm">
+        <div className="flex flex-col gap-3 border-b px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-semibold">Report history</h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Previously generated reports are kept with their audit.
+            </p>
+          </div>
+          {reportsQuery.isError && (
+            <button
+              type="button"
+              onClick={() => void reportsQuery.refetch()}
+              className="text-primary inline-flex items-center gap-1.5 text-sm font-medium hover:underline"
+            >
+              <RefreshCw className="h-3.5 w-3.5" /> Try again
+            </button>
+          )}
+        </div>
 
-                  <div className="flex items-center gap-3">
-                    {badge && (
-                      <span className={`inline-flex items-center gap-1 text-sm ${badge.color}`}>
-                        <badge.icon className="h-4 w-4" />
-                        {report.status}
-                      </span>
-                    )}
-                    <ChevronDown
-                      className={`text-muted-foreground h-4 w-4 transition-transform ${
-                        isExpanded ? 'rotate-180' : ''
-                      }`}
-                    />
-                  </div>
-                </div>
-
-                {isExpanded && (
-                  <div className="bg-muted/10 border-t px-6 py-4">
-                    <div className="grid gap-4 text-sm sm:grid-cols-2">
-                      <div>
-                        <p className="text-muted-foreground font-medium">Audit ID</p>
-                        <Link
-                          href={`/dashboard/audits/${report.auditId}`}
-                          className="text-primary mt-0.5 font-mono hover:underline"
-                        >
-                          {report.auditId}
-                        </Link>
+        {reportsQuery.isLoading ? (
+          <div className="space-y-3 p-6">
+            {[1, 2, 3].map((item) => (
+              <div key={item} className="bg-muted h-16 animate-pulse rounded-lg" />
+            ))}
+          </div>
+        ) : reportsQuery.isError ? (
+          <div className="text-muted-foreground px-6 py-14 text-center text-sm">
+            Report history is temporarily unavailable.
+          </div>
+        ) : history.length === 0 ? (
+          <div className="flex flex-col items-center px-6 py-14 text-center">
+            <Clock3 className="text-muted-foreground/40 h-10 w-10" />
+            <p className="mt-3 text-sm font-medium">No reports generated yet</p>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Your generated reports will show up here.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {history.map((report) => {
+              const expanded = expandedId === report.id;
+              return (
+                <div key={report.id} className="hover:bg-muted/20 transition-colors">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedId(expanded ? null : report.id)}
+                    className="flex w-full items-center justify-between gap-4 px-6 py-4 text-left"
+                  >
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-lg">
+                        <FileText className="h-5 w-5" />
                       </div>
-                      <div>
-                        <p className="text-muted-foreground font-medium">Report Hash</p>
-                        <p className="text-muted-foreground mt-0.5 font-mono">
-                          {report.reportHash ?? 'N/A'}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-muted-foreground font-medium">Generated</p>
-                        <p className="mt-0.5">{report.generatedAt ?? 'N/A'}</p>
-                      </div>
-                      <div>
-                        <p className="text-muted-foreground font-medium">Available Formats</p>
-                        <div className="mt-1 flex flex-wrap gap-1.5">
-                          {report.formats.length > 0 ? (
-                            report.formats.map((fmt) => {
-                              const Icon = formatIcons[fmt] ?? FileText;
-                              return (
-                                <button
-                                  key={fmt}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleDownload(report.id, fmt);
-                                  }}
-                                  className="bg-background hover:bg-muted inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
-                                >
-                                  <Icon className="h-3 w-3" />
-                                  {fmt}
-                                </button>
-                              );
-                            })
-                          ) : (
-                            <span className="text-muted-foreground">None</span>
-                          )}
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{report.projectName}</p>
+                        <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-3 text-xs">
+                          <span className="inline-flex items-center gap-1">
+                            <Calendar className="h-3.5 w-3.5" />
+                            {new Date(report.auditDate).toLocaleDateString()}
+                          </span>
+                          <span>{report.findings} findings</span>
+                          {report.securityScore !== null && <span>{report.securityScore}/100</span>}
                         </div>
                       </div>
                     </div>
-
-                    <div className="mt-4 flex gap-2">
-                      <Link
-                        href={`/dashboard/audits/${report.auditId}`}
-                        className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+                    <div className="flex shrink-0 items-center gap-3">
+                      <span
+                        className={`hidden items-center gap-1 text-xs sm:inline-flex ${statusColors[report.status] ?? 'text-muted-foreground'}`}
                       >
-                        <Eye className="h-4 w-4" /> View Audit
-                      </Link>
-                      <button
-                        onClick={() => handleShare(report.id)}
-                        className="hover:bg-muted inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
-                      >
-                        <Share2 className="h-4 w-4" /> Share
-                      </button>
+                        {report.status === 'VERIFIED' && <ShieldCheck className="h-3.5 w-3.5" />}
+                        {report.status}
+                      </span>
+                      <ChevronDown
+                        className={`text-muted-foreground h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+                      />
                     </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </div>
+                  </button>
+                  {expanded && (
+                    <div className="bg-muted/10 border-t px-6 py-4">
+                      <div className="grid gap-4 text-xs sm:grid-cols-2">
+                        <div>
+                          <p className="text-muted-foreground font-medium">Audit</p>
+                          <Link
+                            href={`/dashboard/audits/${report.auditId}`}
+                            className="text-primary mt-1 inline-block font-mono hover:underline"
+                          >
+                            {report.auditId}
+                          </Link>
+                        </div>
+                        <div>
+                          <p className="text-muted-foreground font-medium">Report hash</p>
+                          <p className="mt-1 break-all font-mono">
+                            {report.reportHash ?? 'Pending'}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {report.formats.map((format) => (
+                          <button
+                            key={format}
+                            type="button"
+                            onClick={() => generateHistoryReport(report, format)}
+                            disabled={generateMutation.isPending}
+                            className="hover:bg-muted rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+                          >
+                            Download {format}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
+import { storeAccessToken } from '@/lib/api-client';
+
 export default function LoginPage() {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
@@ -16,14 +18,37 @@ export default function LoginPage() {
     setLoading(true);
 
     const formData = new FormData(e.currentTarget);
-    const _email = formData.get('email') as string;
-    const _password = formData.get('password') as string;
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
 
-    // TODO: Replace with actual API call
-    await new Promise((r) => setTimeout(r, 800));
-    toast.success('Welcome back!');
-    router.push('/dashboard');
-    setLoading(false);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/api/v1'}/auth/login`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        },
+      );
+      const payload = (await response.json()) as {
+        accessToken?: string;
+        message?: string | string[];
+      };
+      if (!response.ok || !payload.accessToken) {
+        throw new Error(
+          Array.isArray(payload.message)
+            ? payload.message.join(', ')
+            : (payload.message ?? 'Unable to sign in'),
+        );
+      }
+      storeAccessToken(payload.accessToken);
+      toast.success('Welcome back!');
+      router.push('/dashboard');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to sign in');
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
+import { storeAccessToken } from '@/lib/api-client';
+
 export default function RegisterPage() {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
@@ -16,8 +18,8 @@ export default function RegisterPage() {
     setLoading(true);
 
     const formData = new FormData(e.currentTarget);
-    const _displayName = formData.get('displayName') as string;
-    const _email = formData.get('email') as string;
+    const displayName = formData.get('displayName') as string;
+    const email = formData.get('email') as string;
     const password = formData.get('password') as string;
 
     if (!/[A-Z]/.test(password) || !/[a-z]/.test(password) || !/[0-9]/.test(password)) {
@@ -26,11 +28,34 @@ export default function RegisterPage() {
       return;
     }
 
-    // TODO: Replace with actual API call
-    await new Promise((r) => setTimeout(r, 800));
-    toast.success('Account created successfully!');
-    router.push('/dashboard');
-    setLoading(false);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/api/v1'}/auth/register`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ displayName, email, password }),
+        },
+      );
+      const payload = (await response.json()) as {
+        accessToken?: string;
+        message?: string | string[];
+      };
+      if (!response.ok || !payload.accessToken) {
+        throw new Error(
+          Array.isArray(payload.message)
+            ? payload.message.join(', ')
+            : (payload.message ?? 'Unable to create account'),
+        );
+      }
+      storeAccessToken(payload.accessToken);
+      toast.success('Account created successfully!');
+      router.push('/dashboard');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to create account');
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/apps/web/src/components/reports/report-generator.tsx
+++ b/apps/web/src/components/reports/report-generator.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { FileCode2, FileJson, FileText, Globe2, Loader2, Sparkles } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import type { AuditOption, ReportFormat } from '@/lib/api-client';
+
+interface ReportGeneratorProps {
+  audits: AuditOption[];
+  isLoading?: boolean;
+  error?: string | null;
+  onGenerate: (auditId: string, format: ReportFormat, includeAiSummary: boolean) => void;
+}
+
+const formats: Array<{
+  value: ReportFormat;
+  label: string;
+  description: string;
+  icon: typeof FileText;
+}> = [
+  { value: 'MARKDOWN', label: 'Markdown', description: 'Readable source report', icon: FileText },
+  { value: 'HTML', label: 'HTML', description: 'Shareable web report', icon: Globe2 },
+  { value: 'JSON', label: 'JSON', description: 'Machine-readable data', icon: FileJson },
+  { value: 'PDF', label: 'PDF', description: 'Placeholder for export', icon: FileCode2 },
+];
+
+export function ReportGeneratorForm({
+  audits,
+  isLoading = false,
+  error,
+  onGenerate,
+}: ReportGeneratorProps) {
+  const [auditId, setAuditId] = useState('');
+  const [format, setFormat] = useState<ReportFormat>('MARKDOWN');
+  const [includeAiSummary, setIncludeAiSummary] = useState(true);
+
+  useEffect(() => {
+    if (!auditId && audits[0]) setAuditId(audits[0].id);
+  }, [auditId, audits]);
+
+  return (
+    <div className="bg-card rounded-xl border p-6 shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="bg-primary/10 text-primary flex h-10 w-10 items-center justify-center rounded-lg">
+          <Sparkles className="h-5 w-5" />
+        </div>
+        <div>
+          <h2 className="font-semibold">Generate a report</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Choose an audit and format to create a shareable security report.
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="border-destructive/30 bg-destructive/10 text-destructive mt-5 rounded-lg border p-3 text-sm"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="mt-6 space-y-5">
+        <div>
+          <label htmlFor="report-audit" className="text-sm font-medium">
+            Audit
+          </label>
+          <select
+            id="report-audit"
+            value={auditId}
+            onChange={(event) => setAuditId(event.target.value)}
+            disabled={isLoading || audits.length === 0}
+            className="bg-background focus:ring-ring mt-1.5 w-full rounded-lg border px-3 py-2.5 text-sm focus:outline-none focus:ring-2 disabled:opacity-50"
+          >
+            <option value="">{audits.length ? 'Select an audit' : 'No audits available'}</option>
+            {audits.map((audit) => (
+              <option key={audit.id} value={audit.id}>
+                {audit.project.name} · {new Date(audit.createdAt).toLocaleDateString()} ·{' '}
+                {audit.status}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <fieldset>
+          <legend className="text-sm font-medium">Format</legend>
+          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+            {formats.map((item) => {
+              const Icon = item.icon;
+              const selected = format === item.value;
+              return (
+                <label
+                  key={item.value}
+                  className={`flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors ${
+                    selected ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="report-format"
+                    value={item.value}
+                    checked={selected}
+                    onChange={() => setFormat(item.value)}
+                    className="sr-only"
+                  />
+                  <Icon
+                    className={`h-4 w-4 ${selected ? 'text-primary' : 'text-muted-foreground'}`}
+                  />
+                  <span>
+                    <span className="block text-sm font-medium">{item.label}</span>
+                    <span className="text-muted-foreground block text-xs">{item.description}</span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <label className="flex cursor-pointer items-center gap-3 rounded-lg border p-3">
+          <input
+            type="checkbox"
+            checked={includeAiSummary}
+            onChange={(event) => setIncludeAiSummary(event.target.checked)}
+            className="accent-primary h-4 w-4"
+          />
+          <span>
+            <span className="block text-sm font-medium">Include AI analysis</span>
+            <span className="text-muted-foreground block text-xs">
+              Add finding summaries to the report.
+            </span>
+          </span>
+        </label>
+
+        <button
+          type="button"
+          disabled={!auditId || isLoading}
+          onClick={() => onGenerate(auditId, format, includeAiSummary)}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+          {isLoading ? 'Generating...' : 'Generate report'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/reports/report-preview.tsx
+++ b/apps/web/src/components/reports/report-preview.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Check, Clipboard, Download, Eye } from 'lucide-react';
+import { useState } from 'react';
+
+import type { GeneratedReport } from '@/lib/api-client';
+
+interface ReportPreviewProps {
+  report: GeneratedReport;
+}
+
+export function ReportPreview({ report }: ReportPreviewProps) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(report.content);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }
+
+  function handleDownload() {
+    const blob = new Blob([report.content], { type: report.contentType });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `veridion-${report.auditId}.${report.fileExtension}`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <section className="bg-card overflow-hidden rounded-xl border shadow-sm">
+      <div className="flex flex-col gap-3 border-b px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/10">
+            <Eye className="h-4 w-4 text-emerald-500" />
+          </div>
+          <div>
+            <h2 className="font-semibold">Report preview</h2>
+            <p className="text-muted-foreground text-xs">
+              {report.projectName} · {report.format}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="hover:bg-muted inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-medium transition-colors"
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Clipboard className="h-3.5 w-3.5" />}
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors"
+          >
+            <Download className="h-3.5 w-3.5" /> Download .{report.fileExtension}
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-muted/20 max-h-[42rem] overflow-auto p-4 sm:p-6">
+        {report.format === 'HTML' ? (
+          <iframe
+            title="Report HTML preview"
+            srcDoc={report.content}
+            sandbox=""
+            className="h-[34rem] w-full rounded-lg border bg-white"
+          />
+        ) : (
+          <pre className="bg-background overflow-x-auto whitespace-pre-wrap rounded-lg border p-5 font-mono text-xs leading-relaxed">
+            {report.content}
+          </pre>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,0 +1,92 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000/api/v1';
+const ACCESS_TOKEN_KEY = 'veridion_access_token';
+
+export function storeAccessToken(token: string): void {
+  if (typeof window !== 'undefined') window.localStorage.setItem(ACCESS_TOKEN_KEY, token);
+}
+
+interface ApiErrorPayload {
+  message?: string | string[];
+}
+
+export class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'ApiRequestError';
+  }
+}
+
+function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const headers = new Headers(options.headers);
+  const token = getAccessToken();
+  headers.set('Content-Type', 'application/json');
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+
+  const response = await fetch(`${API_URL}${path}`, { ...options, headers });
+  const payload = (await response.json().catch(() => null)) as T | ApiErrorPayload | null;
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' ? (payload as ApiErrorPayload).message : undefined;
+    throw new ApiRequestError(
+      Array.isArray(message) ? message.join(', ') : (message ?? 'Request failed'),
+      response.status,
+    );
+  }
+  return payload as T;
+}
+
+export type ReportFormat = 'JSON' | 'MARKDOWN' | 'HTML' | 'PDF';
+
+export interface ReportHistoryItem {
+  id: string;
+  auditId: string;
+  projectName: string;
+  auditDate: string;
+  securityScore: number | null;
+  findings: number;
+  status: string;
+  generatedAt: string;
+  reportHash: string | null;
+  formats: ReportFormat[];
+}
+
+export interface GeneratedReport extends ReportHistoryItem {
+  format: ReportFormat;
+  content: string;
+  contentType: string;
+  fileExtension: string;
+}
+
+export interface AuditOption {
+  id: string;
+  project: { name: string };
+  status: string;
+  createdAt: string;
+}
+
+export function fetchReports(): Promise<ReportHistoryItem[]> {
+  return apiFetch<ReportHistoryItem[]>('/reports');
+}
+
+export function fetchAudits(): Promise<{ data: AuditOption[] }> {
+  return apiFetch<{ data: AuditOption[] }>('/audits?limit=100');
+}
+
+export function generateReport(
+  auditId: string,
+  format: ReportFormat,
+  includeAiSummary: boolean,
+): Promise<GeneratedReport> {
+  return apiFetch<GeneratedReport>('/reports/generate', {
+    method: 'POST',
+    body: JSON.stringify({ auditId, format, includeAiSummary }),
+  });
+}


### PR DESCRIPTION
Closes #34

## Summary
- replace static report fixtures with API-backed report history and generation
- add audit selection, JSON/Markdown/HTML/PDF-placeholder formats, AI summary toggle, and loading/error/empty states
- preview generated content inline and download it with the correct extension/content type
- use the shared @veridion/report-generator formatters on the API
- add report authorization/history tests and authenticated browser API wiring

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build