### PR TITLE
fix(api): add standard { success, data } response envelope

### DIFF
--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,62 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common';
+import { logger } from '@veridion/logger';
+import type { Response } from 'express';
+
+interface ErrorBody {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  errors?: Array<{ field?: string; message: string; code: string }>;
+  timestamp: string;
+}
+
+/**
+ * Normalizes all thrown HTTP exceptions into a consistent error envelope:
+ * `{ success: false, statusCode, message, errors, timestamp }`.
+ */
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    const isHttpException = exception instanceof HttpException;
+    const status = isHttpException ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    // Extract a human-readable message from the exception.
+    const rawMessage = isHttpException ? exception.getResponse() : null;
+    let message: string;
+    let errors: ErrorBody['errors'];
+
+    if (typeof rawMessage === 'string') {
+      message = rawMessage;
+    } else if (rawMessage && typeof rawMessage === 'object') {
+      const obj = rawMessage as {
+        message?: string | string[];
+        error?: string;
+      };
+      if (Array.isArray(obj.message)) {
+        message = obj.message.join(', ');
+        errors = obj.message.map((m) => ({ message: m, code: 'VALIDATION_ERROR' }));
+      } else {
+        message = obj.message ?? obj.error ?? 'Request failed';
+      }
+    } else {
+      message = 'Internal server error';
+    }
+
+    const body: ErrorBody = {
+      success: false,
+      statusCode: status,
+      message,
+      ...(errors ? { errors } : {}),
+      timestamp: new Date().toISOString(),
+    };
+
+    if (status >= 500) {
+      logger.error({ status, message, error: exception }, 'Unhandled exception');
+    }
+
+    response.status(status).json(body);
+  }
+}

--- a/apps/api/src/common/interceptors/transform.interceptor.ts
+++ b/apps/api/src/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,20 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import type { ApiResponse } from '@veridion/shared';
+import type { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * Wraps every successful API response in the standard `{ success, data }`
+ * envelope expected by the web client and the SDK (`ApiResponse<T>`).
+ */
+@Injectable()
+export class TransformInterceptor<T> implements NestInterceptor<T, ApiResponse<T>> {
+  intercept(_context: ExecutionContext, next: CallHandler<T>): Observable<ApiResponse<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        success: true,
+        data,
+      })),
+    );
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,8 @@ import { logger } from '@veridion/logger';
 import helmet from 'helmet';
 
 import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -25,6 +27,11 @@ async function bootstrap() {
       transformOptions: { enableImplicitConversion: true },
     }),
   );
+
+  // Standard response envelope: { success, data } for success,
+  // { success: false, message, errors } for failures.
+  app.useGlobalInterceptors(new TransformInterceptor());
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   // API prefix
   app.setGlobalPrefix('api/v1');


### PR DESCRIPTION
## Summary

The web client and SDK expect every API response to be wrapped in a `{ success, data }` envelope (per the shared `ApiResponse` type), but the backend was returning raw data. This silently broke every frontend page that consumed the API (audits, auth, AI chat).

## Changes
- Add a global `TransformInterceptor` that wraps successful responses in `{ success: true, data }`.
- Add an `HttpExceptionFilter` that normalizes errors to `{ success: false, message, errors }`.
- Register both in `main.ts`.

This is a foundation prerequisite for the feature PRs.