### PR TITLE
feat: implement audit detail page with findings view (#32)

### DIFF
--- a/apps/api/src/modules/audits/audits.controller.ts
+++ b/apps/api/src/modules/audits/audits.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -29,5 +29,15 @@ export class AuditsController {
   @ApiOperation({ summary: 'Get audit by ID with findings' })
   findOne(@Param('id') id: string, @CurrentUser('id') userId: string) {
     return this.auditsService.findOne(id, userId);
+  }
+
+  @Patch('findings/:id')
+  @ApiOperation({ summary: 'Update finding status' })
+  updateFindingStatus(
+    @Param('id') id: string,
+    @Body() body: { status: string },
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.auditsService.updateFindingStatus(id, body.status, userId);
   }
 }

--- a/apps/api/src/modules/audits/audits.service.ts
+++ b/apps/api/src/modules/audits/audits.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { logger } from '@veridion/logger';
 
 import { CacheService } from '../../common/cache/cache.service';
@@ -110,9 +115,7 @@ export class AuditsService {
   async updateFindingStatus(findingId: string, status: string, userId: string) {
     const validStatuses = ['OPEN', 'ACKNOWLEDGED', 'FALSE_POSITIVE', 'RESOLVED'];
     if (!validStatuses.includes(status)) {
-      throw new BadRequestException(
-        `Invalid status. Must be one of: ${validStatuses.join(', ')}`,
-      );
+      throw new BadRequestException(`Invalid status. Must be one of: ${validStatuses.join(', ')}`);
     }
 
     const finding = await this.prisma.db.auditFinding.findUnique({

--- a/apps/api/src/modules/audits/audits.service.ts
+++ b/apps/api/src/modules/audits/audits.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { logger } from '@veridion/logger';
 
 import { CacheService } from '../../common/cache/cache.service';
@@ -105,5 +105,33 @@ export class AuditsService {
 
   private auditCachePrefix(userId: string): string {
     return `audits:${userId}:`;
+  }
+
+  async updateFindingStatus(findingId: string, status: string, userId: string) {
+    const validStatuses = ['OPEN', 'ACKNOWLEDGED', 'FALSE_POSITIVE', 'RESOLVED'];
+    if (!validStatuses.includes(status)) {
+      throw new BadRequestException(
+        `Invalid status. Must be one of: ${validStatuses.join(', ')}`,
+      );
+    }
+
+    const finding = await this.prisma.db.auditFinding.findUnique({
+      where: { id: findingId },
+      include: { audit: { include: { project: { select: { userId: true } } } } },
+    });
+
+    if (!finding) throw new NotFoundException('Finding not found');
+    if (finding.audit.project.userId !== userId) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    const updated = await this.prisma.db.auditFinding.update({
+      where: { id: findingId },
+      data: { status },
+    });
+
+    logger.info({ findingId, status, userId }, 'Finding status updated');
+
+    return updated;
   }
 }

--- a/apps/web/src/app/dashboard/audits/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/audits/[id]/page.tsx
@@ -67,11 +67,8 @@ export default function AuditDetailPage() {
     setLoading(true);
     setError(null);
     try {
-      const json = await apiGet<{ success: boolean; data: AuditData }>(`/api/v1/audits/${auditId}`);
-      if (!json.success || !json.data) {
-        throw new Error('Failed to load audit');
-      }
-      setAudit(json.data);
+      const json = await apiGet<AuditData>(`/api/v1/audits/${auditId}`);
+      setAudit(json);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load audit');
     } finally {

--- a/apps/web/src/app/dashboard/audits/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/audits/[id]/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import {
   AlertCircle,
@@ -10,15 +10,15 @@ import {
   MessageSquare,
   Shield,
   XCircle,
-} from "lucide-react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+} from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
 
-import type { Finding } from "@/components/audits/finding-card";
-import { FindingList } from "@/components/audits/finding-list";
-import { SeverityChart } from "@/components/audits/severity-chart";
-import { apiGet, apiPatch } from "@/lib/api-helpers";
+import type { Finding } from '@/components/audits/finding-card';
+import { FindingList } from '@/components/audits/finding-list';
+import { SeverityChart } from '@/components/audits/severity-chart';
+import { apiGet, apiPatch } from '@/lib/api-helpers';
 
 interface AuditData {
   id: string;
@@ -46,14 +46,14 @@ const statusIcon: Record<string, React.ElementType> = {
 };
 
 const statusColor: Record<string, string> = {
-  COMPLETED: "text-emerald-500",
-  VERIFIED: "text-violet-500",
-  SCANNING: "text-blue-500",
-  FAILED: "text-red-500",
-  PENDING: "text-amber-500",
+  COMPLETED: 'text-emerald-500',
+  VERIFIED: 'text-violet-500',
+  SCANNING: 'text-blue-500',
+  FAILED: 'text-red-500',
+  PENDING: 'text-amber-500',
 };
 
-const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "GAS", "INFORMATIONAL"];
+const SEVERITY_ORDER = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'GAS', 'INFORMATIONAL'];
 
 export default function AuditDetailPage() {
   const params = useParams();
@@ -67,15 +67,13 @@ export default function AuditDetailPage() {
     setLoading(true);
     setError(null);
     try {
-      const json = await apiGet<{ success: boolean; data: AuditData }>(
-        `/api/v1/audits/${auditId}`,
-      );
+      const json = await apiGet<{ success: boolean; data: AuditData }>(`/api/v1/audits/${auditId}`);
       if (!json.success || !json.data) {
-        throw new Error("Failed to load audit");
+        throw new Error('Failed to load audit');
       }
       setAudit(json.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load audit");
+      setError(err instanceof Error ? err.message : 'Failed to load audit');
     } finally {
       setLoading(false);
     }
@@ -92,9 +90,7 @@ export default function AuditDetailPage() {
       // Optimistic update
       setAudit({
         ...audit,
-        findings: audit.findings.map((f) =>
-          f.id === findingId ? { ...f, status: newStatus } : f,
-        ),
+        findings: audit.findings.map((f) => (f.id === findingId ? { ...f, status: newStatus } : f)),
       });
 
       try {
@@ -102,7 +98,7 @@ export default function AuditDetailPage() {
           status: newStatus,
         });
       } catch (err) {
-        console.error("Failed to update finding status:", err);
+        console.error('Failed to update finding status:', err);
         // Revert on failure
         void fetchAudit();
       }
@@ -134,9 +130,7 @@ export default function AuditDetailPage() {
         <AlertCircle className="text-destructive h-10 w-10" />
         <div className="text-center">
           <h2 className="text-lg font-semibold">Failed to Load Audit</h2>
-          <p className="text-muted-foreground mt-1 text-sm">
-            {error ?? "Audit not found"}
-          </p>
+          <p className="text-muted-foreground mt-1 text-sm">{error ?? 'Audit not found'}</p>
         </div>
         <div className="flex gap-3">
           <Link
@@ -173,7 +167,7 @@ export default function AuditDetailPage() {
       ? formatDuration(audit.startedAt, audit.completedAt)
       : null;
 
-  const completedDate = audit.completedAt?.split("T")[0] ?? null;
+  const completedDate = audit.completedAt?.split('T')[0] ?? null;
 
   return (
     <div className="space-y-6">
@@ -188,10 +182,7 @@ export default function AuditDetailPage() {
         <div className="flex-1">
           <h1 className="text-2xl font-bold tracking-tight">Audit Detail</h1>
           <p className="text-muted-foreground mt-1">
-            <Link
-              href={`/dashboard/projects/${audit.project.id}`}
-              className="hover:text-primary"
-            >
+            <Link href={`/dashboard/projects/${audit.project.id}`} className="hover:text-primary">
               {audit.project.name}
             </Link>
           </p>
@@ -213,46 +204,41 @@ export default function AuditDetailPage() {
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-5">
         {[
           {
-            label: "Security Score",
-            value: audit.securityScore !== null ? `${audit.securityScore}/100` : "—",
+            label: 'Security Score',
+            value: audit.securityScore !== null ? `${audit.securityScore}/100` : '—',
             color:
               audit.securityScore !== null
                 ? audit.securityScore >= 80
-                  ? "text-emerald-500"
+                  ? 'text-emerald-500'
                   : audit.securityScore >= 50
-                    ? "text-amber-500"
-                    : "text-red-500"
-                : "text-muted-foreground",
+                    ? 'text-amber-500'
+                    : 'text-red-500'
+                : 'text-muted-foreground',
           },
           {
-            label: "Status",
+            label: 'Status',
             value: audit.status,
-            color: statusColor[audit.status] ?? "",
+            color: statusColor[audit.status] ?? '',
             icon: StatusIcon,
           },
           {
-            label: "Findings",
+            label: 'Findings',
             value: audit.findings.length,
-            color: "text-violet-500",
+            color: 'text-violet-500',
           },
           {
-            label: "Duration",
-            value: duration ?? "—",
-            color: "text-blue-500",
+            label: 'Duration',
+            value: duration ?? '—',
+            color: 'text-blue-500',
           },
           {
-            label: "Completed",
-            value: completedDate ?? "—",
-            color: "text-muted-foreground",
+            label: 'Completed',
+            value: completedDate ?? '—',
+            color: 'text-muted-foreground',
           },
         ].map((stat) => (
-          <div
-            key={stat.label}
-            className="bg-card rounded-xl border p-4 shadow-sm"
-          >
-            <p className="text-muted-foreground text-xs font-medium">
-              {stat.label}
-            </p>
+          <div key={stat.label} className="bg-card rounded-xl border p-4 shadow-sm">
+            <p className="text-muted-foreground text-xs font-medium">{stat.label}</p>
             <p className={`mt-1 text-2xl font-bold ${stat.color}`}>
               {stat.icon && <stat.icon className="mr-1 inline h-5 w-5" />}
               {stat.value}
@@ -266,28 +252,23 @@ export default function AuditDetailPage() {
         {/* Findings with filters */}
         <div className="lg:col-span-3">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-xl font-bold">
-              Findings ({audit.findings.length})
-            </h2>
+            <h2 className="text-xl font-bold">Findings ({audit.findings.length})</h2>
             <div className="flex flex-wrap gap-1.5">
               {Object.entries(severityCounts)
-                .sort(
-                  (a, b) =>
-                    SEVERITY_ORDER.indexOf(a[0]) - SEVERITY_ORDER.indexOf(b[0]),
-                )
+                .sort((a, b) => SEVERITY_ORDER.indexOf(a[0]) - SEVERITY_ORDER.indexOf(b[0]))
                 .map(([severity, count]) => {
                   const severityBadgeColors: Record<string, string> = {
-                    CRITICAL: "bg-red-500/10 text-red-500",
-                    HIGH: "bg-orange-500/10 text-orange-500",
-                    MEDIUM: "bg-yellow-500/10 text-yellow-500",
-                    LOW: "bg-green-500/10 text-green-500",
-                    GAS: "bg-blue-500/10 text-blue-500",
-                    INFORMATIONAL: "bg-muted text-muted-foreground",
+                    CRITICAL: 'bg-red-500/10 text-red-500',
+                    HIGH: 'bg-orange-500/10 text-orange-500',
+                    MEDIUM: 'bg-yellow-500/10 text-yellow-500',
+                    LOW: 'bg-green-500/10 text-green-500',
+                    GAS: 'bg-blue-500/10 text-blue-500',
+                    INFORMATIONAL: 'bg-muted text-muted-foreground',
                   };
                   return (
                     <span
                       key={severity}
-                      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${severityBadgeColors[severity] ?? ""}`}
+                      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${severityBadgeColors[severity] ?? ''}`}
                     >
                       {severity} {count}
                     </span>
@@ -315,32 +296,24 @@ export default function AuditDetailPage() {
               {audit.commitHash && (
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Commit</span>
-                  <span className="font-mono text-xs">
-                    {audit.commitHash.slice(0, 10)}...
-                  </span>
+                  <span className="font-mono text-xs">{audit.commitHash.slice(0, 10)}...</span>
                 </div>
               )}
               {audit.reportHash && (
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Report Hash</span>
-                  <span className="font-mono text-xs">
-                    {audit.reportHash.slice(0, 10)}...
-                  </span>
+                  <span className="font-mono text-xs">{audit.reportHash.slice(0, 10)}...</span>
                 </div>
               )}
               {audit.transactionHash && (
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Tx Hash</span>
-                  <span className="font-mono text-xs">
-                    {audit.transactionHash.slice(0, 10)}...
-                  </span>
+                  <span className="font-mono text-xs">{audit.transactionHash.slice(0, 10)}...</span>
                 </div>
               )}
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Created</span>
-                <span className="text-xs">
-                  {new Date(audit.createdAt).toLocaleDateString()}
-                </span>
+                <span className="text-xs">{new Date(audit.createdAt).toLocaleDateString()}</span>
               </div>
             </div>
           </div>
@@ -383,7 +356,7 @@ function formatDuration(start: string, end: string): string {
   const diffMs = endDate.getTime() - startDate.getTime();
   const mins = Math.floor(diffMs / 60000);
 
-  if (mins < 1) return "<1 min";
+  if (mins < 1) return '<1 min';
   if (mins < 60) return `${mins} min`;
   const hours = Math.floor(mins / 60);
   const remainingMins = mins % 60;

--- a/apps/web/src/app/dashboard/audits/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/audits/[id]/page.tsx
@@ -1,136 +1,41 @@
-'use client';
+"use client";
 
 import {
+  AlertCircle,
   ArrowLeft,
   CheckCircle2,
   Clock,
   Download,
-  ExternalLink,
-  FileCode,
+  Loader2,
   MessageSquare,
   Shield,
   XCircle,
-} from 'lucide-react';
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
+} from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 
-const audit = {
-  id: 'a1',
-  projectId: '1',
-  projectName: 'DeFi Protocol v2',
-  status: 'COMPLETED',
-  score: 82,
-  commitHash: '0xabc123def456',
-  reportHash: 'report-a1',
-  startedAt: '2024-06-15 10:00',
-  completedAt: '2024-06-15 10:32',
-  duration: '32 min',
-  chain: 'Ethereum',
-  language: 'Solidity',
-};
+import type { Finding } from "@/components/audits/finding-card";
+import { FindingList } from "@/components/audits/finding-list";
+import { SeverityChart } from "@/components/audits/severity-chart";
+import { apiGet, apiPatch } from "@/lib/api-helpers";
 
-const findings = [
-  {
-    id: 'f1',
-    title: 'Reentrancy vulnerability in withdraw function',
-    pluginId: 'reentrancy',
-    severity: 'CRITICAL',
-    filePath: 'LiquidityPool.sol',
-    lineStart: 45,
-    lineEnd: 58,
-    codeSnippet: `function withdraw(uint256 amount) external {\n  require(balances[msg.sender] >= amount, "Insufficient balance");\n  (bool success, ) = msg.sender.call{value: amount}("");\n  require(success, "Transfer failed");\n  balances[msg.sender] -= amount;\n}`,
-    recommendation:
-      'Update the balance before making the external call. Use the Checks-Effects-Interactions pattern to prevent reentrancy attacks.',
-    aiSummary:
-      'This is a classic reentrancy vulnerability where the state update (balance deduction) occurs after the external call. An attacker could re-enter the withdraw function before their balance is updated, draining funds.',
-    confidence: 0.95,
-    status: 'OPEN',
-    references: [
-      'https://swcregistry.io/docs/SWC-107',
-      'https://consensys.github.io/smart-contract-best-practices/attacks/reentrancy/',
-    ],
-  },
-  {
-    id: 'f2',
-    title: 'Unchecked return value from external call',
-    pluginId: 'access-control',
-    severity: 'HIGH',
-    filePath: 'LiquidityPool.sol',
-    lineStart: 102,
-    lineEnd: 112,
-    codeSnippet: `function transferOwnership(address newOwner) external {\n  require(msg.sender == owner, "Not owner");\n  pendingOwner = newOwner;\n}`,
-    recommendation:
-      'Implement a two-step ownership transfer pattern with a confirmation step from the new owner to prevent accidental transfers.',
-    aiSummary:
-      'The single-step ownership transfer can lead to permanent loss of control if the wrong address is provided. A two-step pattern with acceptOwnership() from the new owner is recommended.',
-    confidence: 0.88,
-    status: 'ACKNOWLEDGED',
-    references: [
-      'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable2Step.sol',
-    ],
-  },
-  {
-    id: 'f3',
-    title: 'Gas inefficient loop in batchTransfer',
-    pluginId: 'gas',
-    severity: 'GAS',
-    filePath: 'StakingRewards.sol',
-    lineStart: 78,
-    lineEnd: 90,
-    codeSnippet: `function batchTransfer(address[] calldata recipients, uint256[] calldata amounts) external {\n  for (uint256 i = 0; i < recipients.length; i++) {\n    balances[recipients[i]] += amounts[i];\n  }\n}`,
-    recommendation:
-      'Cache the array length before the loop and consider using unchecked blocks for arithmetic operations where overflow is not a concern in Solidity 0.8+.',
-    aiSummary:
-      'Reading recipients.length on each iteration costs extra gas. Caching it in a local variable reduces gas costs significantly for large arrays.',
-    confidence: 0.72,
-    status: 'OPEN',
-    references: [],
-  },
-  {
-    id: 'f4',
-    title: 'Missing zero-address validation',
-    pluginId: 'access-control',
-    severity: 'LOW',
-    filePath: 'Governance.sol',
-    lineStart: 15,
-    lineEnd: 19,
-    codeSnippet: `function setAdmin(address newAdmin) external onlyOwner {\n  admin = newAdmin;\n}`,
-    recommendation:
-      'Add a check to prevent setting admin to address(0) which would permanently lose admin capabilities.',
-    aiSummary:
-      'Setting a privileged role to the zero address results in permanent loss of that functionality. Always validate address parameters.',
-    confidence: 0.99,
-    status: 'RESOLVED',
-    references: [],
-  },
-  {
-    id: 'f5',
-    title: 'Unprotected selfdestruct',
-    pluginId: 'access-control',
-    severity: 'MEDIUM',
-    filePath: 'YieldFarm.sol',
-    lineStart: 200,
-    lineEnd: 205,
-    codeSnippet: `function emergencyStop() external {\n  selfdestruct(payable(msg.sender));\n}`,
-    recommendation:
-      'Add an onlyOwner or multi-signature requirement to selfdestruct to prevent unauthorized destruction of the contract.',
-    aiSummary:
-      'Anyone can call selfdestruct and destroy the contract, taking all funds and rendering the protocol unusable. Restrict this to the owner or a multisig.',
-    confidence: 0.85,
-    status: 'OPEN',
-    references: [
-      'https://docs.soliditylang.org/en/latest/security-considerations.html#selfdestruct',
-    ],
-  },
-];
-
-const severityConfig: Record<string, { color: string; bg: string; border: string }> = {
-  CRITICAL: { color: 'text-red-500', bg: 'bg-red-500/10', border: 'border-red-500/30' },
-  HIGH: { color: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/30' },
-  MEDIUM: { color: 'text-yellow-500', bg: 'bg-yellow-500/10', border: 'border-yellow-500/30' },
-  LOW: { color: 'text-green-500', bg: 'bg-green-500/10', border: 'border-green-500/30' },
-  GAS: { color: 'text-blue-500', bg: 'bg-blue-500/10', border: 'border-blue-500/30' },
-};
+interface AuditData {
+  id: string;
+  status: string;
+  securityScore: number | null;
+  commitHash: string | null;
+  reportHash: string | null;
+  transactionHash: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  project: {
+    id: string;
+    name: string;
+  };
+  findings: Finding[];
+}
 
 const statusIcon: Record<string, React.ElementType> = {
   COMPLETED: CheckCircle2,
@@ -141,19 +46,121 @@ const statusIcon: Record<string, React.ElementType> = {
 };
 
 const statusColor: Record<string, string> = {
-  COMPLETED: 'text-emerald-500',
-  VERIFIED: 'text-violet-500',
-  SCANNING: 'text-blue-500',
-  FAILED: 'text-red-500',
-  PENDING: 'text-amber-500',
+  COMPLETED: "text-emerald-500",
+  VERIFIED: "text-violet-500",
+  SCANNING: "text-blue-500",
+  FAILED: "text-red-500",
+  PENDING: "text-amber-500",
 };
+
+const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "GAS", "INFORMATIONAL"];
 
 export default function AuditDetailPage() {
   const params = useParams();
-  const _auditId = params.id as string;
-  const StatusIcon = statusIcon[audit.status] ?? Clock;
+  const auditId = params.id as string;
 
-  const severityCounts = findings.reduce(
+  const [audit, setAudit] = useState<AuditData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAudit = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const json = await apiGet<{ success: boolean; data: AuditData }>(
+        `/api/v1/audits/${auditId}`,
+      );
+      if (!json.success || !json.data) {
+        throw new Error("Failed to load audit");
+      }
+      setAudit(json.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load audit");
+    } finally {
+      setLoading(false);
+    }
+  }, [auditId]);
+
+  useEffect(() => {
+    void fetchAudit();
+  }, [fetchAudit]);
+
+  const handleStatusChange = useCallback(
+    async (findingId: string, newStatus: string) => {
+      if (!audit) return;
+
+      // Optimistic update
+      setAudit({
+        ...audit,
+        findings: audit.findings.map((f) =>
+          f.id === findingId ? { ...f, status: newStatus } : f,
+        ),
+      });
+
+      try {
+        await apiPatch(`/api/v1/audits/findings/${findingId}`, {
+          status: newStatus,
+        });
+      } catch (err) {
+        console.error("Failed to update finding status:", err);
+        // Revert on failure
+        void fetchAudit();
+      }
+    },
+    [audit, fetchAudit],
+  );
+
+  const handleVerifyOnChain = useCallback(() => {
+    if (!audit) return;
+    // Placeholder: will be wired to blockchain verification in #40 or a future issue
+    alert(
+      `Blockchain verification for audit ${audit.id} will be available soon. Connect your Stellar wallet to proceed.`,
+    );
+  }, [audit]);
+
+  // ---- Loading state ----
+  if (loading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="text-primary h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  // ---- Error state ----
+  if (error || !audit) {
+    return (
+      <div className="flex h-96 flex-col items-center justify-center gap-4">
+        <AlertCircle className="text-destructive h-10 w-10" />
+        <div className="text-center">
+          <h2 className="text-lg font-semibold">Failed to Load Audit</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            {error ?? "Audit not found"}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Link
+            href="/dashboard/audits"
+            className="bg-card hover:bg-muted rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
+          >
+            Back to Audits
+          </Link>
+          <button
+            onClick={() => {
+              void fetchAudit();
+            }}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ---- Compute derived data ----
+  const StatusIcon = statusIcon[audit.status] ?? Clock;
+  const severityCounts = audit.findings.reduce(
     (acc, f) => {
       acc[f.severity] = (acc[f.severity] ?? 0) + 1;
       return acc;
@@ -161,9 +168,17 @@ export default function AuditDetailPage() {
     {} as Record<string, number>,
   );
 
+  const duration =
+    audit.startedAt && audit.completedAt
+      ? formatDuration(audit.startedAt, audit.completedAt)
+      : null;
+
+  const completedDate = audit.completedAt?.split("T")[0] ?? null;
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-4">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-4">
         <Link
           href="/dashboard/audits"
           className="text-muted-foreground hover:bg-muted hover:text-foreground rounded-lg p-2 transition-colors"
@@ -171,52 +186,73 @@ export default function AuditDetailPage() {
           <ArrowLeft className="h-5 w-5" />
         </Link>
         <div className="flex-1">
-          <h1 className="text-3xl font-bold tracking-tight">Audit Detail</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Audit Detail</h1>
           <p className="text-muted-foreground mt-1">
-            <Link href={`/dashboard/projects/${audit.projectId}`} className="hover:text-primary">
-              {audit.projectName}
-            </Link>{' '}
-            · {audit.chain}
+            <Link
+              href={`/dashboard/projects/${audit.project.id}`}
+              className="hover:text-primary"
+            >
+              {audit.project.name}
+            </Link>
           </p>
         </div>
         <div className="flex gap-2">
           <button className="hover:bg-muted inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors">
             <Download className="h-4 w-4" /> Export
           </button>
-          <button className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors">
+          <button
+            onClick={handleVerifyOnChain}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+          >
             <Shield className="h-4 w-4" /> Verify on-chain
           </button>
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-5">
+      {/* Stats grid */}
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-5">
         {[
           {
-            label: 'Security Score',
-            value: `${audit.score}/100`,
+            label: "Security Score",
+            value: audit.securityScore !== null ? `${audit.securityScore}/100` : "—",
             color:
-              audit.score >= 80
-                ? 'text-emerald-500'
-                : audit.score >= 50
-                  ? 'text-amber-500'
-                  : 'text-red-500',
+              audit.securityScore !== null
+                ? audit.securityScore >= 80
+                  ? "text-emerald-500"
+                  : audit.securityScore >= 50
+                    ? "text-amber-500"
+                    : "text-red-500"
+                : "text-muted-foreground",
           },
           {
-            label: 'Status',
+            label: "Status",
             value: audit.status,
-            color: statusColor[audit.status] ?? '',
+            color: statusColor[audit.status] ?? "",
             icon: StatusIcon,
           },
-          { label: 'Findings', value: findings.length, color: 'text-violet-500' },
-          { label: 'Duration', value: audit.duration, color: 'text-blue-500' },
           {
-            label: 'Completed',
-            value: audit.completedAt?.split(' ')[0] ?? '—',
-            color: 'text-muted-foreground',
+            label: "Findings",
+            value: audit.findings.length,
+            color: "text-violet-500",
+          },
+          {
+            label: "Duration",
+            value: duration ?? "—",
+            color: "text-blue-500",
+          },
+          {
+            label: "Completed",
+            value: completedDate ?? "—",
+            color: "text-muted-foreground",
           },
         ].map((stat) => (
-          <div key={stat.label} className="bg-card rounded-xl border p-4 shadow-sm">
-            <p className="text-muted-foreground text-xs font-medium">{stat.label}</p>
+          <div
+            key={stat.label}
+            className="bg-card rounded-xl border p-4 shadow-sm"
+          >
+            <p className="text-muted-foreground text-xs font-medium">
+              {stat.label}
+            </p>
             <p className={`mt-1 text-2xl font-bold ${stat.color}`}>
               {stat.icon && <stat.icon className="mr-1 inline h-5 w-5" />}
               {stat.value}
@@ -225,119 +261,131 @@ export default function AuditDetailPage() {
         ))}
       </div>
 
-      <div className="flex items-center gap-4">
-        <h2 className="text-xl font-bold">Findings ({findings.length})</h2>
-        <div className="flex gap-1.5">
-          {Object.entries(severityCounts).map(([severity, count]) => {
-            const config = severityConfig[severity];
-            return (
-              <span
-                key={severity}
-                className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${config?.bg ?? ''} ${config?.color ?? ''}`}
-              >
-                {severity} {count}
-              </span>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        {findings.map((finding) => {
-          const config = severityConfig[finding.severity] ?? severityConfig.LOW;
-          return (
-            <div
-              key={finding.id}
-              className={`bg-card rounded-xl border shadow-sm ${config?.border ?? ''}`}
-            >
-              <div className="flex items-start justify-between border-b px-6 py-4">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
+      {/* Main content: findings + sidebar */}
+      <div className="grid gap-6 lg:grid-cols-4">
+        {/* Findings with filters */}
+        <div className="lg:col-span-3">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-xl font-bold">
+              Findings ({audit.findings.length})
+            </h2>
+            <div className="flex flex-wrap gap-1.5">
+              {Object.entries(severityCounts)
+                .sort(
+                  (a, b) =>
+                    SEVERITY_ORDER.indexOf(a[0]) - SEVERITY_ORDER.indexOf(b[0]),
+                )
+                .map(([severity, count]) => {
+                  const severityBadgeColors: Record<string, string> = {
+                    CRITICAL: "bg-red-500/10 text-red-500",
+                    HIGH: "bg-orange-500/10 text-orange-500",
+                    MEDIUM: "bg-yellow-500/10 text-yellow-500",
+                    LOW: "bg-green-500/10 text-green-500",
+                    GAS: "bg-blue-500/10 text-blue-500",
+                    INFORMATIONAL: "bg-muted text-muted-foreground",
+                  };
+                  return (
                     <span
-                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${config?.bg ?? ''} ${config?.color ?? ''}`}
+                      key={severity}
+                      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${severityBadgeColors[severity] ?? ""}`}
                     >
-                      {finding.severity}
+                      {severity} {count}
                     </span>
-                    <span className="text-muted-foreground text-xs">
-                      {finding.filePath}:{finding.lineStart}-{finding.lineEnd}
-                    </span>
-                    <span className="text-muted-foreground text-xs">
-                      {(finding.confidence * 100).toFixed(0)}% confidence
-                    </span>
-                  </div>
-                  <h3 className="text-lg font-semibold">{finding.title}</h3>
+                  );
+                })}
+            </div>
+          </div>
+
+          <FindingList
+            findings={audit.findings}
+            onStatusChange={(id, status) => {
+              void handleStatusChange(id, status);
+            }}
+          />
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-4">
+          <SeverityChart counts={severityCounts} />
+
+          {/* Audit metadata */}
+          <div className="bg-card rounded-xl border p-6 shadow-sm">
+            <h3 className="text-sm font-semibold">Audit Info</h3>
+            <div className="mt-3 space-y-2 text-sm">
+              {audit.commitHash && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Commit</span>
+                  <span className="font-mono text-xs">
+                    {audit.commitHash.slice(0, 10)}...
+                  </span>
                 </div>
-                <span
-                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                    finding.status === 'OPEN'
-                      ? 'bg-red-500/10 text-red-500'
-                      : finding.status === 'ACKNOWLEDGED'
-                        ? 'bg-amber-500/10 text-amber-500'
-                        : finding.status === 'RESOLVED'
-                          ? 'bg-emerald-500/10 text-emerald-500'
-                          : 'bg-muted text-muted-foreground'
-                  }`}
-                >
-                  {finding.status}
+              )}
+              {audit.reportHash && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Report Hash</span>
+                  <span className="font-mono text-xs">
+                    {audit.reportHash.slice(0, 10)}...
+                  </span>
+                </div>
+              )}
+              {audit.transactionHash && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Tx Hash</span>
+                  <span className="font-mono text-xs">
+                    {audit.transactionHash.slice(0, 10)}...
+                  </span>
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Created</span>
+                <span className="text-xs">
+                  {new Date(audit.createdAt).toLocaleDateString()}
                 </span>
               </div>
-
-              <div className="space-y-4 px-6 py-4">
-                {finding.aiSummary && (
-                  <div className="bg-muted/50 rounded-lg p-4">
-                    <div className="flex items-start gap-2">
-                      <MessageSquare className="text-primary mt-0.5 h-4 w-4 shrink-0" />
-                      <div>
-                        <p className="text-primary text-xs font-medium">AI Analysis</p>
-                        <p className="mt-1 text-sm leading-relaxed">{finding.aiSummary}</p>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {finding.codeSnippet && (
-                  <div>
-                    <p className="text-muted-foreground mb-2 text-xs font-medium">
-                      <FileCode className="mr-1 inline h-3.5 w-3.5" />
-                      Vulnerable Code
-                    </p>
-                    <pre className="overflow-x-auto rounded-lg bg-zinc-950 p-4 text-sm text-zinc-100">
-                      <code>{finding.codeSnippet}</code>
-                    </pre>
-                  </div>
-                )}
-
-                {finding.recommendation && (
-                  <div>
-                    <p className="text-muted-foreground mb-1 text-xs font-medium">Recommendation</p>
-                    <p className="text-sm leading-relaxed">{finding.recommendation}</p>
-                  </div>
-                )}
-
-                {finding.references.length > 0 && (
-                  <div>
-                    <p className="text-muted-foreground mb-1 text-xs font-medium">References</p>
-                    <div className="flex flex-wrap gap-2">
-                      {finding.references.map((ref) => (
-                        <a
-                          key={ref}
-                          href={ref}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="bg-muted hover:bg-muted/80 inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs transition-colors"
-                        >
-                          {ref.length > 50 ? `${ref.slice(0, 50)}...` : ref}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
             </div>
-          );
-        })}
+          </div>
+
+          {/* Quick Actions */}
+          <div className="bg-card rounded-xl border p-6 shadow-sm">
+            <h3 className="text-sm font-semibold">Quick Actions</h3>
+            <div className="mt-3 space-y-2">
+              <button className="hover:bg-muted w-full rounded-lg border px-4 py-2.5 text-left text-sm font-medium transition-colors">
+                <Download className="mr-2 inline h-4 w-4" />
+                Download Report
+              </button>
+              <button
+                onClick={handleVerifyOnChain}
+                className="hover:bg-muted w-full rounded-lg border px-4 py-2.5 text-left text-sm font-medium transition-colors"
+              >
+                <Shield className="mr-2 inline h-4 w-4" />
+                Verify on Stellar
+              </button>
+              <Link
+                href="/dashboard/ai-chat"
+                className="hover:bg-muted block w-full rounded-lg border px-4 py-2.5 text-left text-sm font-medium transition-colors"
+              >
+                <MessageSquare className="mr-2 inline h-4 w-4" />
+                Ask AI About Findings
+              </Link>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );
+}
+
+// ---- Helpers ----
+
+function formatDuration(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const diffMs = endDate.getTime() - startDate.getTime();
+  const mins = Math.floor(diffMs / 60000);
+
+  if (mins < 1) return "<1 min";
+  if (mins < 60) return `${mins} min`;
+  const hours = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+  return remainingMins > 0 ? `${hours}h ${remainingMins}m` : `${hours}h`;
 }

--- a/apps/web/src/app/dashboard/audits/page.tsx
+++ b/apps/web/src/app/dashboard/audits/page.tsx
@@ -19,18 +19,15 @@ interface AuditItem {
   };
 }
 
-interface ApiResponse {
-  success: boolean;
-  data: {
-    data: AuditItem[];
-    meta: {
-      total: number;
-      page: number;
-      limit: number;
-      totalPages: number;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-    };
+interface AuditsResponse {
+  data: AuditItem[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
   };
 }
 
@@ -63,10 +60,8 @@ export default function AuditsPage() {
         const params = new URLSearchParams({ limit: '50', sortOrder: 'desc' });
         if (statusFilter) params.set('status', statusFilter);
 
-        const json = await apiGet<ApiResponse>(`/api/v1/audits?${params.toString()}`);
-        if (json.success && json.data) {
-          setAudits(json.data.data);
-        }
+        const json = await apiGet<AuditsResponse>(`/api/v1/audits?${params.toString()}`);
+        setAudits(json.data);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load audits');
       } finally {

--- a/apps/web/src/app/dashboard/audits/page.tsx
+++ b/apps/web/src/app/dashboard/audits/page.tsx
@@ -1,45 +1,48 @@
-import { CheckCircle2, Clock, Shield, XCircle } from 'lucide-react';
+"use client";
 
-const audits = [
-  {
-    id: '1',
-    project: 'DeFi Protocol v2',
-    status: 'COMPLETED',
-    score: 82,
-    findings: 14,
-    date: '2024-06-15',
-    hash: '0xabc...def',
-  },
-  {
-    id: '2',
-    project: 'NFT Marketplace',
-    status: 'SCANNING',
-    score: null,
-    findings: null,
-    date: '2024-06-10',
-    hash: '0x123...456',
-  },
-  {
-    id: '3',
-    project: 'Staking Rewards',
-    status: 'VERIFIED',
-    score: 93,
-    findings: 3,
-    date: '2024-05-28',
-    hash: '0x789...012',
-  },
-  {
-    id: '4',
-    project: 'Token Vesting',
-    status: 'FAILED',
-    score: null,
-    findings: null,
-    date: '2024-05-20',
-    hash: '0xdef...abc',
-  },
-];
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  Search,
+  Shield,
+  XCircle,
+} from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 
-const statusIcon = {
+import { apiGet } from "@/lib/api-helpers";
+
+interface AuditItem {
+  id: string;
+  status: string;
+  securityScore: number | null;
+  createdAt: string;
+  project: {
+    name: string;
+  };
+  _count: {
+    findings: number;
+  };
+}
+
+interface ApiResponse {
+  success: boolean;
+  data: {
+    data: AuditItem[];
+    meta: {
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+    };
+  };
+}
+
+const statusIcon: Record<string, React.ElementType> = {
   COMPLETED: CheckCircle2,
   SCANNING: Clock,
   VERIFIED: Shield,
@@ -47,52 +50,167 @@ const statusIcon = {
   PENDING: Clock,
 };
 
-const statusColor = {
-  COMPLETED: 'text-emerald-500',
-  SCANNING: 'text-blue-500',
-  VERIFIED: 'text-violet-500',
-  FAILED: 'text-red-500',
-  PENDING: 'text-amber-500',
+const statusColor: Record<string, string> = {
+  COMPLETED: "text-emerald-500",
+  SCANNING: "text-blue-500",
+  VERIFIED: "text-violet-500",
+  FAILED: "text-red-500",
+  PENDING: "text-amber-500",
 };
 
 export default function AuditsPage() {
+  const [audits, setAudits] = useState<AuditItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+
+  useEffect(() => {
+    async function fetchAudits() {
+      try {
+        const params = new URLSearchParams({ limit: "50", sortOrder: "desc" });
+        if (statusFilter) params.set("status", statusFilter);
+
+        const json = await apiGet<ApiResponse>(
+          `/api/v1/audits?${params.toString()}`,
+        );
+        if (json.success && json.data) {
+          setAudits(json.data.data);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load audits");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void fetchAudits();
+  }, [statusFilter]);
+
+  const filteredAudits = audits.filter((a) => {
+    if (search && !a.project.name.toLowerCase().includes(search.toLowerCase())) {
+      return false;
+    }
+    return true;
+  });
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="text-primary h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex h-96 flex-col items-center justify-center gap-4">
+        <AlertCircle className="text-destructive h-10 w-10" />
+        <div className="text-center">
+          <h2 className="text-lg font-semibold">Failed to Load Audits</h2>
+          <p className="text-muted-foreground mt-1 text-sm">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Audit History</h1>
-        <p className="text-muted-foreground mt-1">Review past audits and their findings.</p>
+        <p className="text-muted-foreground mt-1">
+          Review past audits and their findings.
+        </p>
       </div>
 
-      <div className="bg-card rounded-xl border">
-        <div className="p-6">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px] max-w-xs">
+          <Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search audits..."
+            className="bg-background focus:ring-ring w-full rounded-lg border py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2"
+          />
+        </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="bg-background focus:ring-ring rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+        >
+          <option value="">All Statuses</option>
+          <option value="COMPLETED">Completed</option>
+          <option value="SCANNING">Scanning</option>
+          <option value="VERIFIED">Verified</option>
+          <option value="FAILED">Failed</option>
+          <option value="PENDING">Pending</option>
+        </select>
+      </div>
+
+      {/* Empty state */}
+      {filteredAudits.length === 0 ? (
+        <div className="bg-card rounded-xl border p-12 text-center">
+          <Search className="text-muted-foreground mx-auto mb-3 h-8 w-8" />
+          <p className="text-muted-foreground text-sm">
+            {audits.length === 0
+              ? "No audits yet. Run your first audit to get started."
+              : "No audits match your search."}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-card overflow-hidden rounded-xl border">
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="text-muted-foreground border-b text-left text-sm">
-                  <th className="pb-3 font-medium">Project</th>
+                  <th className="pb-3 pl-6 font-medium">Project</th>
                   <th className="pb-3 font-medium">Status</th>
                   <th className="pb-3 font-medium">Score</th>
                   <th className="pb-3 font-medium">Findings</th>
-                  <th className="pb-3 font-medium">Date</th>
+                  <th className="pb-3 pr-6 font-medium">Date</th>
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {audits.map((audit) => {
-                  const Icon = statusIcon[audit.status as keyof typeof statusIcon] ?? Clock;
+                {filteredAudits.map((audit) => {
+                  const Icon = statusIcon[audit.status] ?? Clock;
                   const color =
-                    statusColor[audit.status as keyof typeof statusColor] ??
-                    'text-muted-foreground';
+                    statusColor[audit.status] ?? "text-muted-foreground";
                   return (
-                    <tr key={audit.id} className="hover:bg-muted/50 text-sm transition-colors">
-                      <td className="py-3 font-medium">{audit.project}</td>
+                    <tr key={audit.id}>
+                      <td className="py-3 pl-6">
+                        <Link
+                          href={`/dashboard/audits/${audit.id}`}
+                          className="hover:text-primary text-sm font-medium transition-colors"
+                        >
+                          {audit.project.name}
+                        </Link>
+                      </td>
                       <td className="py-3">
-                        <span className={`inline-flex items-center gap-1 ${color}`}>
+                        <span
+                          className={`inline-flex items-center gap-1 text-sm ${color}`}
+                        >
                           <Icon className="h-3.5 w-3.5" /> {audit.status}
                         </span>
                       </td>
-                      <td className="py-3">{audit.score ? `${audit.score}/100` : '—'}</td>
-                      <td className="py-3">{audit.findings ?? '—'}</td>
-                      <td className="text-muted-foreground py-3">{audit.date}</td>
+                      <td className="py-3">
+                        <span className="text-sm">
+                          {audit.securityScore !== null
+                            ? `${audit.securityScore}/100`
+                            : "—"}
+                        </span>
+                      </td>
+                      <td className="py-3">
+                        <span className="text-sm">
+                          {audit._count?.findings ?? "—"}
+                        </span>
+                      </td>
+                      <td className="text-muted-foreground py-3 pr-6 text-sm">
+                        {new Date(audit.createdAt).toLocaleDateString()}
+                      </td>
                     </tr>
                   );
                 })}
@@ -100,7 +218,9 @@ export default function AuditsPage() {
             </table>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }
+
+

--- a/apps/web/src/app/dashboard/audits/page.tsx
+++ b/apps/web/src/app/dashboard/audits/page.tsx
@@ -1,18 +1,10 @@
-"use client";
+'use client';
 
-import {
-  AlertCircle,
-  CheckCircle2,
-  Clock,
-  Loader2,
-  Search,
-  Shield,
-  XCircle,
-} from "lucide-react";
-import Link from "next/link";
-import { useEffect, useState } from "react";
+import { AlertCircle, CheckCircle2, Clock, Loader2, Search, Shield, XCircle } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
-import { apiGet } from "@/lib/api-helpers";
+import { apiGet } from '@/lib/api-helpers';
 
 interface AuditItem {
   id: string;
@@ -51,34 +43,32 @@ const statusIcon: Record<string, React.ElementType> = {
 };
 
 const statusColor: Record<string, string> = {
-  COMPLETED: "text-emerald-500",
-  SCANNING: "text-blue-500",
-  VERIFIED: "text-violet-500",
-  FAILED: "text-red-500",
-  PENDING: "text-amber-500",
+  COMPLETED: 'text-emerald-500',
+  SCANNING: 'text-blue-500',
+  VERIFIED: 'text-violet-500',
+  FAILED: 'text-red-500',
+  PENDING: 'text-amber-500',
 };
 
 export default function AuditsPage() {
   const [audits, setAudits] = useState<AuditItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
 
   useEffect(() => {
     async function fetchAudits() {
       try {
-        const params = new URLSearchParams({ limit: "50", sortOrder: "desc" });
-        if (statusFilter) params.set("status", statusFilter);
+        const params = new URLSearchParams({ limit: '50', sortOrder: 'desc' });
+        if (statusFilter) params.set('status', statusFilter);
 
-        const json = await apiGet<ApiResponse>(
-          `/api/v1/audits?${params.toString()}`,
-        );
+        const json = await apiGet<ApiResponse>(`/api/v1/audits?${params.toString()}`);
         if (json.success && json.data) {
           setAudits(json.data.data);
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load audits");
+        setError(err instanceof Error ? err.message : 'Failed to load audits');
       } finally {
         setLoading(false);
       }
@@ -120,21 +110,19 @@ export default function AuditsPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Audit History</h1>
-        <p className="text-muted-foreground mt-1">
-          Review past audits and their findings.
-        </p>
+        <p className="text-muted-foreground mt-1">Review past audits and their findings.</p>
       </div>
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 min-w-[200px] max-w-xs">
+        <div className="relative min-w-[200px] max-w-xs flex-1">
           <Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
           <input
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search audits..."
-            className="bg-background focus:ring-ring w-full rounded-lg border py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2"
+            className="bg-background focus:ring-ring placeholder:text-muted-foreground w-full rounded-lg border py-2 pl-9 pr-3 text-sm focus:outline-none focus:ring-2"
           />
         </div>
         <select
@@ -157,8 +145,8 @@ export default function AuditsPage() {
           <Search className="text-muted-foreground mx-auto mb-3 h-8 w-8" />
           <p className="text-muted-foreground text-sm">
             {audits.length === 0
-              ? "No audits yet. Run your first audit to get started."
-              : "No audits match your search."}
+              ? 'No audits yet. Run your first audit to get started.'
+              : 'No audits match your search.'}
           </p>
         </div>
       ) : (
@@ -177,8 +165,7 @@ export default function AuditsPage() {
               <tbody className="divide-y">
                 {filteredAudits.map((audit) => {
                   const Icon = statusIcon[audit.status] ?? Clock;
-                  const color =
-                    statusColor[audit.status] ?? "text-muted-foreground";
+                  const color = statusColor[audit.status] ?? 'text-muted-foreground';
                   return (
                     <tr key={audit.id}>
                       <td className="py-3 pl-6">
@@ -190,23 +177,17 @@ export default function AuditsPage() {
                         </Link>
                       </td>
                       <td className="py-3">
-                        <span
-                          className={`inline-flex items-center gap-1 text-sm ${color}`}
-                        >
+                        <span className={`inline-flex items-center gap-1 text-sm ${color}`}>
                           <Icon className="h-3.5 w-3.5" /> {audit.status}
                         </span>
                       </td>
                       <td className="py-3">
                         <span className="text-sm">
-                          {audit.securityScore !== null
-                            ? `${audit.securityScore}/100`
-                            : "—"}
+                          {audit.securityScore !== null ? `${audit.securityScore}/100` : '—'}
                         </span>
                       </td>
                       <td className="py-3">
-                        <span className="text-sm">
-                          {audit._count?.findings ?? "—"}
-                        </span>
+                        <span className="text-sm">{audit._count?.findings ?? '—'}</span>
                       </td>
                       <td className="text-muted-foreground py-3 pr-6 text-sm">
                         {new Date(audit.createdAt).toLocaleDateString()}
@@ -222,5 +203,3 @@ export default function AuditsPage() {
     </div>
   );
 }
-
-

--- a/apps/web/src/components/audits/finding-card.tsx
+++ b/apps/web/src/components/audits/finding-card.tsx
@@ -1,12 +1,7 @@
-"use client";
+'use client';
 
-import {
-  ChevronDown,
-  ExternalLink,
-  FileCode,
-  MessageSquare,
-} from "lucide-react";
-import { useState } from "react";
+import { ChevronDown, ExternalLink, FileCode, MessageSquare } from 'lucide-react';
+import { useState } from 'react';
 
 export interface Finding {
   id: string;
@@ -30,34 +25,42 @@ interface FindingCardProps {
   onStatusChange: (findingId: string, newStatus: string) => void;
 }
 
-export const severityConfig: Record<string, { color: string; bg: string; border: string } | undefined> = {
-  CRITICAL: { color: "text-red-500", bg: "bg-red-500/10", border: "border-l-red-500" },
-  HIGH: { color: "text-orange-500", bg: "bg-orange-500/10", border: "border-l-orange-500" },
-  MEDIUM: { color: "text-yellow-500", bg: "bg-yellow-500/10", border: "border-l-yellow-500" },
-  LOW: { color: "text-green-500", bg: "bg-green-500/10", border: "border-l-green-500" },
-  GAS: { color: "text-blue-500", bg: "bg-blue-500/10", border: "border-l-blue-500" },
-  INFORMATIONAL: { color: "text-muted-foreground", bg: "bg-muted", border: "border-l-muted-foreground" },
+export const severityConfig: Record<
+  string,
+  { color: string; bg: string; border: string } | undefined
+> = {
+  CRITICAL: { color: 'text-red-500', bg: 'bg-red-500/10', border: 'border-l-red-500' },
+  HIGH: { color: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-l-orange-500' },
+  MEDIUM: { color: 'text-yellow-500', bg: 'bg-yellow-500/10', border: 'border-l-yellow-500' },
+  LOW: { color: 'text-green-500', bg: 'bg-green-500/10', border: 'border-l-green-500' },
+  GAS: { color: 'text-blue-500', bg: 'bg-blue-500/10', border: 'border-l-blue-500' },
+  INFORMATIONAL: {
+    color: 'text-muted-foreground',
+    bg: 'bg-muted',
+    border: 'border-l-muted-foreground',
+  },
 };
 
 const statusOptions = [
-  { value: "OPEN", label: "Open" },
-  { value: "ACKNOWLEDGED", label: "Acknowledged" },
-  { value: "FALSE_POSITIVE", label: "False Positive" },
-  { value: "RESOLVED", label: "Resolved" },
+  { value: 'OPEN', label: 'Open' },
+  { value: 'ACKNOWLEDGED', label: 'Acknowledged' },
+  { value: 'FALSE_POSITIVE', label: 'False Positive' },
+  { value: 'RESOLVED', label: 'Resolved' },
 ];
 
 export function FindingCard({ finding, onStatusChange }: FindingCardProps) {
   const [expanded, setExpanded] = useState(false);
   const defaultConfig: { color: string; bg: string; border: string } = {
-    color: "text-muted-foreground",
-    bg: "bg-muted",
-    border: "border-l-muted-foreground",
+    color: 'text-muted-foreground',
+    bg: 'bg-muted',
+    border: 'border-l-muted-foreground',
   };
   const config = severityConfig[finding.severity] ?? defaultConfig;
 
   return (
     <div
-      className={`bg-card rounded-xl border shadow-sm border-l-4 ${config.border}`}
+      id={`finding-${finding.id}`}
+      className={`bg-card rounded-xl border border-l-4 shadow-sm ${config.border}`}
     >
       {/* Header */}
       <button
@@ -71,7 +74,7 @@ export function FindingCard({ finding, onStatusChange }: FindingCardProps) {
             >
               {finding.severity}
             </span>
-            <span className="text-muted-foreground text-xs font-mono">
+            <span className="text-muted-foreground font-mono text-xs">
               {finding.filePath}:{finding.lineStart}-{finding.lineEnd}
             </span>
             <span className="text-muted-foreground text-xs">
@@ -90,14 +93,14 @@ export function FindingCard({ finding, onStatusChange }: FindingCardProps) {
               onStatusChange(finding.id, e.target.value);
             }}
             onClick={(e) => e.stopPropagation()}
-            className={`rounded-full border px-2.5 py-0.5 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-primary ${
-              finding.status === "OPEN"
-                ? "border-red-500/30 bg-red-500/10 text-red-500"
-                : finding.status === "ACKNOWLEDGED"
-                  ? "border-amber-500/30 bg-amber-500/10 text-amber-500"
-                  : finding.status === "RESOLVED"
-                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-500"
-                    : "border-muted bg-muted text-muted-foreground"
+            className={`focus:ring-primary rounded-full border px-2.5 py-0.5 text-xs font-medium focus:outline-none focus:ring-2 ${
+              finding.status === 'OPEN'
+                ? 'border-red-500/30 bg-red-500/10 text-red-500'
+                : finding.status === 'ACKNOWLEDGED'
+                  ? 'border-amber-500/30 bg-amber-500/10 text-amber-500'
+                  : finding.status === 'RESOLVED'
+                    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-500'
+                    : 'border-muted bg-muted text-muted-foreground'
             }`}
           >
             {statusOptions.map((opt) => (
@@ -109,7 +112,7 @@ export function FindingCard({ finding, onStatusChange }: FindingCardProps) {
 
           <ChevronDown
             className={`text-muted-foreground h-4 w-4 transition-transform ${
-              expanded ? "rotate-180" : ""
+              expanded ? 'rotate-180' : ''
             }`}
           />
         </div>

--- a/apps/web/src/components/audits/finding-card.tsx
+++ b/apps/web/src/components/audits/finding-card.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import {
+  ChevronDown,
+  ExternalLink,
+  FileCode,
+  MessageSquare,
+} from "lucide-react";
+import { useState } from "react";
+
+export interface Finding {
+  id: string;
+  title: string;
+  pluginId: string;
+  severity: string;
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+  codeSnippet: string | null;
+  description: string;
+  recommendation: string | null;
+  aiSummary: string | null;
+  confidence: number;
+  status: string;
+  references?: string[];
+}
+
+interface FindingCardProps {
+  finding: Finding;
+  onStatusChange: (findingId: string, newStatus: string) => void;
+}
+
+export const severityConfig: Record<string, { color: string; bg: string; border: string } | undefined> = {
+  CRITICAL: { color: "text-red-500", bg: "bg-red-500/10", border: "border-l-red-500" },
+  HIGH: { color: "text-orange-500", bg: "bg-orange-500/10", border: "border-l-orange-500" },
+  MEDIUM: { color: "text-yellow-500", bg: "bg-yellow-500/10", border: "border-l-yellow-500" },
+  LOW: { color: "text-green-500", bg: "bg-green-500/10", border: "border-l-green-500" },
+  GAS: { color: "text-blue-500", bg: "bg-blue-500/10", border: "border-l-blue-500" },
+  INFORMATIONAL: { color: "text-muted-foreground", bg: "bg-muted", border: "border-l-muted-foreground" },
+};
+
+const statusOptions = [
+  { value: "OPEN", label: "Open" },
+  { value: "ACKNOWLEDGED", label: "Acknowledged" },
+  { value: "FALSE_POSITIVE", label: "False Positive" },
+  { value: "RESOLVED", label: "Resolved" },
+];
+
+export function FindingCard({ finding, onStatusChange }: FindingCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const defaultConfig: { color: string; bg: string; border: string } = {
+    color: "text-muted-foreground",
+    bg: "bg-muted",
+    border: "border-l-muted-foreground",
+  };
+  const config = severityConfig[finding.severity] ?? defaultConfig;
+
+  return (
+    <div
+      className={`bg-card rounded-xl border shadow-sm border-l-4 ${config.border}`}
+    >
+      {/* Header */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-start justify-between px-6 py-4 text-left"
+      >
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${config.bg} ${config.color}`}
+            >
+              {finding.severity}
+            </span>
+            <span className="text-muted-foreground text-xs font-mono">
+              {finding.filePath}:{finding.lineStart}-{finding.lineEnd}
+            </span>
+            <span className="text-muted-foreground text-xs">
+              {(finding.confidence * 100).toFixed(0)}% confidence
+            </span>
+          </div>
+          <h3 className="text-base font-semibold">{finding.title}</h3>
+        </div>
+
+        <div className="ml-4 flex shrink-0 items-center gap-3">
+          {/* Status selector */}
+          <select
+            value={finding.status}
+            onChange={(e) => {
+              e.stopPropagation();
+              onStatusChange(finding.id, e.target.value);
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className={`rounded-full border px-2.5 py-0.5 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-primary ${
+              finding.status === "OPEN"
+                ? "border-red-500/30 bg-red-500/10 text-red-500"
+                : finding.status === "ACKNOWLEDGED"
+                  ? "border-amber-500/30 bg-amber-500/10 text-amber-500"
+                  : finding.status === "RESOLVED"
+                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-500"
+                    : "border-muted bg-muted text-muted-foreground"
+            }`}
+          >
+            {statusOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+
+          <ChevronDown
+            className={`text-muted-foreground h-4 w-4 transition-transform ${
+              expanded ? "rotate-180" : ""
+            }`}
+          />
+        </div>
+      </button>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="space-y-4 border-t px-6 py-4">
+          {/* Description */}
+          <div>
+            <p className="text-muted-foreground mb-1 text-xs font-medium">Description</p>
+            <p className="text-sm leading-relaxed">{finding.description}</p>
+          </div>
+
+          {/* AI Summary */}
+          {finding.aiSummary && (
+            <div className="bg-muted/50 rounded-lg p-4">
+              <div className="flex items-start gap-2">
+                <MessageSquare className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                <div>
+                  <p className="text-primary text-xs font-medium">AI Analysis</p>
+                  <p className="mt-1 text-sm leading-relaxed">{finding.aiSummary}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Code Snippet */}
+          {finding.codeSnippet && (
+            <div>
+              <p className="text-muted-foreground mb-2 text-xs font-medium">
+                <FileCode className="mr-1 inline h-3.5 w-3.5" />
+                Vulnerable Code
+              </p>
+              <pre className="overflow-x-auto rounded-lg bg-zinc-950 p-4 text-sm text-zinc-100">
+                <code>{finding.codeSnippet}</code>
+              </pre>
+            </div>
+          )}
+
+          {/* Recommendation */}
+          {finding.recommendation && (
+            <div>
+              <p className="text-muted-foreground mb-1 text-xs font-medium">Recommendation</p>
+              <p className="text-sm leading-relaxed">{finding.recommendation}</p>
+            </div>
+          )}
+
+          {/* References */}
+          {finding.references && finding.references.length > 0 && (
+            <div>
+              <p className="text-muted-foreground mb-1 text-xs font-medium">References</p>
+              <div className="flex flex-wrap gap-2">
+                {finding.references.map((ref) => (
+                  <a
+                    key={ref}
+                    href={ref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="bg-muted hover:bg-muted/80 inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs transition-colors"
+                  >
+                    {ref.length > 50 ? `${ref.slice(0, 50)}...` : ref}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/audits/finding-list.tsx
+++ b/apps/web/src/components/audits/finding-list.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Filter, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { type Finding,FindingCard } from "./finding-card";
+
+interface FindingListProps {
+  findings: Finding[];
+  onStatusChange: (findingId: string, newStatus: string) => void;
+}
+
+const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "GAS", "INFORMATIONAL"];
+
+export function FindingList({ findings, onStatusChange }: FindingListProps) {
+  const [search, setSearch] = useState("");
+  const [severityFilter, setSeverityFilter] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+
+  const availablePlugins = useMemo(() => {
+    const plugins = new Set(findings.map((f) => f.pluginId));
+    return Array.from(plugins).sort();
+  }, [findings]);
+
+  const [pluginFilter, setPluginFilter] = useState<string>("");
+
+  const filteredFindings = useMemo(() => {
+    return findings.filter((f) => {
+      if (search && !f.title.toLowerCase().includes(search.toLowerCase())) {
+        return false;
+      }
+      if (severityFilter && f.severity !== severityFilter) return false;
+      if (statusFilter && f.status !== statusFilter) return false;
+      if (pluginFilter && f.pluginId !== pluginFilter) return false;
+      return true;
+    });
+  }, [findings, search, severityFilter, statusFilter, pluginFilter]);
+
+  const severityCounts = useMemo(() => {
+    return findings.reduce(
+      (acc, f) => {
+        acc[f.severity] = (acc[f.severity] ?? 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+  }, [findings]);
+
+  const hasActiveFilters = search || severityFilter || statusFilter || pluginFilter;
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Search */}
+        <div className="relative flex-1 min-w-[200px] max-w-xs">
+          <Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search findings..."
+            className="bg-background focus:ring-ring w-full rounded-lg border py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2"
+          />
+        </div>
+
+        {/* Severity filter */}
+        <select
+          value={severityFilter}
+          onChange={(e) => setSeverityFilter(e.target.value)}
+          className="bg-background focus:ring-ring rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+        >
+          <option value="">All Severities</option>
+          {severityOrder.map((s) => (
+            <option key={s} value={s}>
+              {s} ({severityCounts[s] ?? 0})
+            </option>
+          ))}
+        </select>
+
+        {/* Status filter */}
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="bg-background focus:ring-ring rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+        >
+          <option value="">All Statuses</option>
+          <option value="OPEN">Open</option>
+          <option value="ACKNOWLEDGED">Acknowledged</option>
+          <option value="FALSE_POSITIVE">False Positive</option>
+          <option value="RESOLVED">Resolved</option>
+        </select>
+
+        {/* Plugin filter */}
+        {availablePlugins.length > 1 && (
+          <select
+            value={pluginFilter}
+            onChange={(e) => setPluginFilter(e.target.value)}
+            className="bg-background focus:ring-ring rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+          >
+            <option value="">All Plugins</option>
+            {availablePlugins.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {/* Active filter indicator */}
+        {hasActiveFilters && (
+          <button
+            onClick={() => {
+              setSearch("");
+              setSeverityFilter("");
+              setStatusFilter("");
+              setPluginFilter("");
+            }}
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
+          >
+            <Filter className="h-3 w-3" />
+            Clear filters ({filteredFindings.length})
+          </button>
+        )}
+      </div>
+
+      {/* Findings list */}
+      {filteredFindings.length === 0 ? (
+        <div className="bg-card rounded-xl border p-12 text-center">
+          <Search className="text-muted-foreground mx-auto mb-3 h-8 w-8" />
+          <p className="text-muted-foreground text-sm">
+            {hasActiveFilters
+              ? "No findings match your filters. Try adjusting or clearing them."
+              : "No findings detected for this audit."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filteredFindings.map((finding) => (
+            <FindingCard
+              key={finding.id}
+              finding={finding}
+              onStatusChange={onStatusChange}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/audits/finding-list.tsx
+++ b/apps/web/src/components/audits/finding-list.tsx
@@ -1,28 +1,28 @@
-"use client";
+'use client';
 
-import { Filter, Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Filter, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
-import { type Finding,FindingCard } from "./finding-card";
+import { type Finding, FindingCard } from './finding-card';
 
 interface FindingListProps {
   findings: Finding[];
   onStatusChange: (findingId: string, newStatus: string) => void;
 }
 
-const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "GAS", "INFORMATIONAL"];
+const severityOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'GAS', 'INFORMATIONAL'];
 
 export function FindingList({ findings, onStatusChange }: FindingListProps) {
-  const [search, setSearch] = useState("");
-  const [severityFilter, setSeverityFilter] = useState<string>("");
-  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [search, setSearch] = useState('');
+  const [severityFilter, setSeverityFilter] = useState<string>('');
+  const [statusFilter, setStatusFilter] = useState<string>('');
 
   const availablePlugins = useMemo(() => {
     const plugins = new Set(findings.map((f) => f.pluginId));
     return Array.from(plugins).sort();
   }, [findings]);
 
-  const [pluginFilter, setPluginFilter] = useState<string>("");
+  const [pluginFilter, setPluginFilter] = useState<string>('');
 
   const filteredFindings = useMemo(() => {
     return findings.filter((f) => {
@@ -53,14 +53,14 @@ export function FindingList({ findings, onStatusChange }: FindingListProps) {
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-3">
         {/* Search */}
-        <div className="relative flex-1 min-w-[200px] max-w-xs">
+        <div className="relative min-w-[200px] max-w-xs flex-1">
           <Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
           <input
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search findings..."
-            className="bg-background focus:ring-ring w-full rounded-lg border py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2"
+            className="bg-background focus:ring-ring placeholder:text-muted-foreground w-full rounded-lg border py-2 pl-9 pr-3 text-sm focus:outline-none focus:ring-2"
           />
         </div>
 
@@ -111,10 +111,10 @@ export function FindingList({ findings, onStatusChange }: FindingListProps) {
         {hasActiveFilters && (
           <button
             onClick={() => {
-              setSearch("");
-              setSeverityFilter("");
-              setStatusFilter("");
-              setPluginFilter("");
+              setSearch('');
+              setSeverityFilter('');
+              setStatusFilter('');
+              setPluginFilter('');
             }}
             className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
           >
@@ -130,18 +130,14 @@ export function FindingList({ findings, onStatusChange }: FindingListProps) {
           <Search className="text-muted-foreground mx-auto mb-3 h-8 w-8" />
           <p className="text-muted-foreground text-sm">
             {hasActiveFilters
-              ? "No findings match your filters. Try adjusting or clearing them."
-              : "No findings detected for this audit."}
+              ? 'No findings match your filters. Try adjusting or clearing them.'
+              : 'No findings detected for this audit.'}
           </p>
         </div>
       ) : (
         <div className="space-y-3">
           {filteredFindings.map((finding) => (
-            <FindingCard
-              key={finding.id}
-              finding={finding}
-              onStatusChange={onStatusChange}
-            />
+            <FindingCard key={finding.id} finding={finding} onStatusChange={onStatusChange} />
           ))}
         </div>
       )}

--- a/apps/web/src/components/audits/severity-chart.tsx
+++ b/apps/web/src/components/audits/severity-chart.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Cell, Legend,Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+
+interface SeverityChartProps {
+  counts: Record<string, number>;
+}
+
+const severityConfig: Record<string, { label: string; color: string }> = {
+  CRITICAL: { label: "Critical", color: "#ef4444" },
+  HIGH: { label: "High", color: "#f97316" },
+  MEDIUM: { label: "Medium", color: "#eab308" },
+  LOW: { label: "Low", color: "#22c55e" },
+  GAS: { label: "Gas", color: "#3b82f6" },
+  INFORMATIONAL: { label: "Info", color: "#6b7280" },
+};
+
+const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "GAS", "INFORMATIONAL"];
+
+export function SeverityChart({ counts }: SeverityChartProps) {
+  const data = severityOrder
+    .filter((s) => counts[s] && counts[s] > 0)
+    .map((s) => ({
+      name: severityConfig[s]?.label ?? s,
+      value: counts[s] ?? 0,
+      color: severityConfig[s]?.color ?? "#6b7280",
+    }));
+
+  if (data.length === 0) {
+    return (
+      <div className="bg-card rounded-xl border p-6 shadow-sm">
+        <h3 className="text-sm font-semibold">Severity Distribution</h3>
+        <p className="text-muted-foreground mt-4 text-center text-sm">
+          No findings to display
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-xl border p-6 shadow-sm">
+      <h3 className="text-sm font-semibold">Severity Distribution</h3>
+      <div className="mt-2 h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              cx="50%"
+              cy="50%"
+              innerRadius={40}
+              outerRadius={70}
+              paddingAngle={3}
+              dataKey="value"
+              strokeWidth={0}
+            >
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              contentStyle={{
+                background: "hsl(var(--card))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+            />
+            <Legend
+              verticalAlign="bottom"
+              height={36}
+              iconType="circle"
+              iconSize={8}
+              formatter={(value: string) => (
+                <span className="text-xs">{value}</span>
+              )}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/audits/severity-chart.tsx
+++ b/apps/web/src/components/audits/severity-chart.tsx
@@ -1,21 +1,21 @@
-"use client";
+'use client';
 
-import { Cell, Legend,Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
 
 interface SeverityChartProps {
   counts: Record<string, number>;
 }
 
 const severityConfig: Record<string, { label: string; color: string }> = {
-  CRITICAL: { label: "Critical", color: "#ef4444" },
-  HIGH: { label: "High", color: "#f97316" },
-  MEDIUM: { label: "Medium", color: "#eab308" },
-  LOW: { label: "Low", color: "#22c55e" },
-  GAS: { label: "Gas", color: "#3b82f6" },
-  INFORMATIONAL: { label: "Info", color: "#6b7280" },
+  CRITICAL: { label: 'Critical', color: '#ef4444' },
+  HIGH: { label: 'High', color: '#f97316' },
+  MEDIUM: { label: 'Medium', color: '#eab308' },
+  LOW: { label: 'Low', color: '#22c55e' },
+  GAS: { label: 'Gas', color: '#3b82f6' },
+  INFORMATIONAL: { label: 'Info', color: '#6b7280' },
 };
 
-const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "GAS", "INFORMATIONAL"];
+const severityOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'GAS', 'INFORMATIONAL'];
 
 export function SeverityChart({ counts }: SeverityChartProps) {
   const data = severityOrder
@@ -23,16 +23,14 @@ export function SeverityChart({ counts }: SeverityChartProps) {
     .map((s) => ({
       name: severityConfig[s]?.label ?? s,
       value: counts[s] ?? 0,
-      color: severityConfig[s]?.color ?? "#6b7280",
+      color: severityConfig[s]?.color ?? '#6b7280',
     }));
 
   if (data.length === 0) {
     return (
       <div className="bg-card rounded-xl border p-6 shadow-sm">
         <h3 className="text-sm font-semibold">Severity Distribution</h3>
-        <p className="text-muted-foreground mt-4 text-center text-sm">
-          No findings to display
-        </p>
+        <p className="text-muted-foreground mt-4 text-center text-sm">No findings to display</p>
       </div>
     );
   }
@@ -59,10 +57,10 @@ export function SeverityChart({ counts }: SeverityChartProps) {
             </Pie>
             <Tooltip
               contentStyle={{
-                background: "hsl(var(--card))",
-                border: "1px solid hsl(var(--border))",
-                borderRadius: "8px",
-                fontSize: "12px",
+                background: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px',
+                fontSize: '12px',
               }}
             />
             <Legend
@@ -70,9 +68,7 @@ export function SeverityChart({ counts }: SeverityChartProps) {
               height={36}
               iconType="circle"
               iconSize={8}
-              formatter={(value: string) => (
-                <span className="text-xs">{value}</span>
-              )}
+              formatter={(value: string) => <span className="text-xs">{value}</span>}
             />
           </PieChart>
         </ResponsiveContainer>

--- a/apps/web/src/lib/api-helpers.ts
+++ b/apps/web/src/lib/api-helpers.ts
@@ -1,6 +1,6 @@
 export function getAuthToken(): string | null {
   if (typeof window === 'undefined') return null;
-  return localStorage.getItem('accessToken');
+  return localStorage.getItem('veridion_access_token');
 }
 
 export function getApiBaseUrl(): string {

--- a/apps/web/src/lib/api-helpers.ts
+++ b/apps/web/src/lib/api-helpers.ts
@@ -1,0 +1,74 @@
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("accessToken");
+}
+
+export function getApiBaseUrl(): string {
+  if (typeof window === "undefined") return "http://localhost:4000";
+  return process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const token = getAuthToken();
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!res.ok) {
+    const errorData = (await res.json().catch(() => null)) as { message?: string };
+    throw new Error(errorData?.message ?? `Request failed with status ${res.status}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
+  const token = getAuthToken();
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const errorData = (await res.json().catch(() => null)) as { message?: string };
+    throw new Error(errorData?.message ?? `Request failed with status ${res.status}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export async function apiPatch<T>(path: string, body?: unknown): Promise<T> {
+  const token = getAuthToken();
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const errorData = (await res.json().catch(() => null)) as { message?: string };
+    throw new Error(errorData?.message ?? `Request failed with status ${res.status}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export async function apiDelete(path: string): Promise<void> {
+  const token = getAuthToken();
+  await fetch(`${getApiBaseUrl()}${path}`, {
+    method: "DELETE",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+}

--- a/apps/web/src/lib/api-helpers.ts
+++ b/apps/web/src/lib/api-helpers.ts
@@ -1,18 +1,18 @@
 export function getAuthToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem("accessToken");
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('accessToken');
 }
 
 export function getApiBaseUrl(): string {
-  if (typeof window === "undefined") return "http://localhost:4000";
-  return process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+  if (typeof window === 'undefined') return 'http://localhost:4000';
+  return process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 }
 
 export async function apiGet<T>(path: string): Promise<T> {
   const token = getAuthToken();
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
   });
@@ -28,9 +28,9 @@ export async function apiGet<T>(path: string): Promise<T> {
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   const token = getAuthToken();
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: body ? JSON.stringify(body) : undefined,
@@ -47,9 +47,9 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
 export async function apiPatch<T>(path: string, body?: unknown): Promise<T> {
   const token = getAuthToken();
   const res = await fetch(`${getApiBaseUrl()}${path}`, {
-    method: "PATCH",
+    method: 'PATCH',
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: body ? JSON.stringify(body) : undefined,
@@ -66,7 +66,7 @@ export async function apiPatch<T>(path: string, body?: unknown): Promise<T> {
 export async function apiDelete(path: string): Promise<void> {
   const token = getAuthToken();
   await fetch(`${getApiBaseUrl()}${path}`, {
-    method: "DELETE",
+    method: 'DELETE',
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },


### PR DESCRIPTION
## Summary

Implements the audit detail page with a findings view (issue #32).

## Changes
- Add audit detail route (`/dashboard/audits/[id]`) with finding list, severity chart, and finding cards.
- Add shared `api-helpers.ts` for typed API calls (`apiGet`/`apiPost`).
- Update the audits service/controller for detail lookups.
- Apply Prettier formatting to satisfy CI `format:check`.

Closes #32