### PR TITLE
feat: implement authentication flow (#35)

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,10 +1,13 @@
+import { ProtectedRoute } from '@/components/auth/protected-route';
 import { Sidebar } from '@/components/sidebar';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <main className="bg-muted/10 flex-1 overflow-y-auto p-6 lg:p-8">{children}</main>
-    </div>
+    <ProtectedRoute>
+      <div className="flex h-screen overflow-hidden">
+        <Sidebar />
+        <main className="bg-muted/10 flex-1 overflow-y-auto p-6 lg:p-8">{children}</main>
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,38 +1,53 @@
 'use client';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Eye, EyeOff, Lock, Mail, Shield } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { z } from 'zod';
 
-import { apiFetch, storeAccessToken } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth';
+
+const loginSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+type LoginForm = z.infer<typeof loginSchema>;
 
 export default function LoginPage() {
+  const { login, isAuthenticated } = useAuth();
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setLoading(true);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginForm>({
+    resolver: zodResolver(loginSchema),
+  });
 
-    const formData = new FormData(e.currentTarget);
-    const email = formData.get('email') as string;
-    const password = formData.get('password') as string;
+  // Redirect if already authenticated
+  if (isAuthenticated) {
+    router.replace('/dashboard');
+    return null;
+  }
 
+  async function onSubmit(data: LoginForm) {
+    setServerError(null);
     try {
-      const response = await apiFetch<{ accessToken: string }>('/auth/login', {
-        method: 'POST',
-        body: JSON.stringify({ email, password }),
-      });
-      storeAccessToken(response.accessToken);
+      await login(data.email, data.password);
       toast.success('Welcome back!');
       router.push('/dashboard');
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Unable to sign in');
-    } finally {
-      setLoading(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed';
+      setServerError(message);
+      toast.error(message);
     }
   }
 
@@ -49,12 +64,20 @@ export default function LoginPage() {
         </div>
 
         <div className="bg-card rounded-xl border p-6 shadow-sm">
+          {/* Server error */}
+          {serverError && (
+            <div className="bg-destructive/10 text-destructive mb-4 rounded-lg px-4 py-2.5 text-sm">
+              {serverError}
+            </div>
+          )}
+
           <form
             onSubmit={(e) => {
-              void handleSubmit(e);
+              void handleSubmit(onSubmit)(e);
             }}
             className="space-y-5"
           >
+            {/* Email */}
             <div>
               <label htmlFor="email" className="text-sm font-medium">
                 Email address
@@ -63,16 +86,21 @@ export default function LoginPage() {
                 <Mail className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
                 <input
                   id="email"
-                  name="email"
                   type="email"
                   autoComplete="email"
-                  required
                   placeholder="you@example.com"
-                  className="bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2"
+                  className={`bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2 ${
+                    errors.email ? 'border-destructive' : ''
+                  }`}
+                  {...register('email')}
                 />
               </div>
+              {errors.email && (
+                <p className="text-destructive mt-1 text-xs">{errors.email.message}</p>
+              )}
             </div>
 
+            {/* Password */}
             <div>
               <div className="flex items-center justify-between">
                 <label htmlFor="password" className="text-sm font-medium">
@@ -89,30 +117,35 @@ export default function LoginPage() {
                 <Lock className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
                 <input
                   id="password"
-                  name="password"
                   type={showPassword ? 'text' : 'password'}
                   autoComplete="current-password"
-                  required
-                  minLength={8}
                   placeholder="Enter your password"
-                  className="bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-10 text-sm focus:outline-none focus:ring-2"
+                  className={`bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-10 text-sm focus:outline-none focus:ring-2 ${
+                    errors.password ? 'border-destructive' : ''
+                  }`}
+                  {...register('password')}
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
                   className="text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
+              {errors.password && (
+                <p className="text-destructive mt-1 text-xs">{errors.password.message}</p>
+              )}
             </div>
 
+            {/* Submit */}
             <button
               type="submit"
-              disabled={loading}
+              disabled={isSubmitting}
               className="bg-primary text-primary-foreground hover:bg-primary/90 w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {loading ? 'Signing in...' : 'Sign in'}
+              {isSubmitting ? 'Signing in...' : 'Sign in'}
             </button>
           </form>
 

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,45 +1,49 @@
 'use client';
 
+import { zodResolver } from '@hookform/resolvers/zod';
+import { registerSchema } from '@veridion/shared';
 import { Eye, EyeOff, Lock, Mail, Shield, User } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { type z } from 'zod';
 
-import { apiFetch, storeAccessToken } from '@/lib/api-client';
+import { useAuth } from '@/lib/auth';
+
+type RegisterForm = z.infer<typeof registerSchema>;
 
 export default function RegisterPage() {
+  const { register: registerUser, isAuthenticated } = useAuth();
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setLoading(true);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterForm>({
+    resolver: zodResolver(registerSchema),
+  });
 
-    const formData = new FormData(e.currentTarget);
-    const displayName = formData.get('displayName') as string;
-    const email = formData.get('email') as string;
-    const password = formData.get('password') as string;
+  // Redirect if already authenticated
+  if (isAuthenticated) {
+    router.replace('/dashboard');
+    return null;
+  }
 
-    if (!/[A-Z]/.test(password) || !/[a-z]/.test(password) || !/[0-9]/.test(password)) {
-      toast.error('Password must contain uppercase, lowercase, and a number');
-      setLoading(false);
-      return;
-    }
-
+  async function onSubmit(data: RegisterForm) {
+    setServerError(null);
     try {
-      const response = await apiFetch<{ accessToken: string }>('/auth/register', {
-        method: 'POST',
-        body: JSON.stringify({ displayName, email, password }),
-      });
-      storeAccessToken(response.accessToken);
+      await registerUser(data.email, data.password, data.displayName);
       toast.success('Account created successfully!');
       router.push('/dashboard');
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Unable to create account');
-    } finally {
-      setLoading(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Registration failed';
+      setServerError(message);
+      toast.error(message);
     }
   }
 
@@ -58,12 +62,20 @@ export default function RegisterPage() {
         </div>
 
         <div className="bg-card rounded-xl border p-6 shadow-sm">
+          {/* Server error */}
+          {serverError && (
+            <div className="bg-destructive/10 text-destructive mb-4 rounded-lg px-4 py-2.5 text-sm">
+              {serverError}
+            </div>
+          )}
+
           <form
             onSubmit={(e) => {
-              void handleSubmit(e);
+              void handleSubmit(onSubmit)(e);
             }}
             className="space-y-5"
           >
+            {/* Display name */}
             <div>
               <label htmlFor="displayName" className="text-sm font-medium">
                 Display name
@@ -72,17 +84,20 @@ export default function RegisterPage() {
                 <User className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
                 <input
                   id="displayName"
-                  name="displayName"
                   type="text"
-                  required
-                  minLength={2}
-                  maxLength={50}
                   placeholder="John Doe"
-                  className="bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2"
+                  className={`bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2 ${
+                    errors.displayName ? 'border-destructive' : ''
+                  }`}
+                  {...register('displayName')}
                 />
               </div>
+              {errors.displayName && (
+                <p className="text-destructive mt-1 text-xs">{errors.displayName.message}</p>
+              )}
             </div>
 
+            {/* Email */}
             <div>
               <label htmlFor="email" className="text-sm font-medium">
                 Email address
@@ -91,16 +106,21 @@ export default function RegisterPage() {
                 <Mail className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
                 <input
                   id="email"
-                  name="email"
                   type="email"
                   autoComplete="email"
-                  required
                   placeholder="you@example.com"
-                  className="bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2"
+                  className={`bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2 ${
+                    errors.email ? 'border-destructive' : ''
+                  }`}
+                  {...register('email')}
                 />
               </div>
+              {errors.email && (
+                <p className="text-destructive mt-1 text-xs">{errors.email.message}</p>
+              )}
             </div>
 
+            {/* Password */}
             <div>
               <label htmlFor="password" className="text-sm font-medium">
                 Password
@@ -109,34 +129,39 @@ export default function RegisterPage() {
                 <Lock className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
                 <input
                   id="password"
-                  name="password"
                   type={showPassword ? 'text' : 'password'}
                   autoComplete="new-password"
-                  required
-                  minLength={8}
                   placeholder="Min. 8 characters, uppercase, lowercase, number"
-                  className="bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-10 text-sm focus:outline-none focus:ring-2"
+                  className={`bg-background placeholder:text-muted-foreground focus:ring-ring w-full rounded-lg border py-2 pl-10 pr-10 text-sm focus:outline-none focus:ring-2 ${
+                    errors.password ? 'border-destructive' : ''
+                  }`}
+                  {...register('password')}
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
                   className="text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
+              {errors.password && (
+                <p className="text-destructive mt-1 text-xs">{errors.password.message}</p>
+              )}
               <p className="text-muted-foreground mt-1.5 text-xs">
                 Must contain at least 8 characters, one uppercase letter, one lowercase letter, and
                 one number.
               </p>
             </div>
 
+            {/* Submit */}
             <button
               type="submit"
-              disabled={loading}
+              disabled={isSubmitting}
               className="bg-primary text-primary-foreground hover:bg-primary/90 w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {loading ? 'Creating account...' : 'Create account'}
+              {isSubmitting ? 'Creating account...' : 'Create account'}
             </button>
           </form>
 

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useAuth } from '@/lib/auth';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Loader2 className="text-primary h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/query-provider.tsx
+++ b/apps/web/src/components/query-provider.tsx
@@ -3,6 +3,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { AuthProvider } from '@/lib/auth';
+
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
     () =>
@@ -17,5 +19,9 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       }),
   );
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
 }

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   FolderOpen,
   LayoutDashboard,
+  LogOut,
   MessageSquare,
   Settings,
   Shield,
@@ -15,6 +16,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 
+import { useAuth } from '@/lib/auth';
 import { cn } from '@/lib/utils';
 
 const navigation = [
@@ -29,6 +31,7 @@ const navigation = [
 export function Sidebar() {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
+  const { user, logout } = useAuth();
 
   return (
     <aside
@@ -37,6 +40,7 @@ export function Sidebar() {
         collapsed ? 'w-16' : 'w-64',
       )}
     >
+      {/* Logo */}
       <div className="flex h-14 items-center justify-between border-b px-4">
         {!collapsed && (
           <Link href="/dashboard" className="flex items-center gap-2 font-bold">
@@ -45,11 +49,16 @@ export function Sidebar() {
           </Link>
         )}
         {collapsed && <Shield className="text-primary mx-auto h-6 w-6" />}
-        <button onClick={() => setCollapsed(!collapsed)} className="hover:bg-muted rounded-md p-1">
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="hover:bg-muted rounded-md p-1"
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
           <ChevronLeft className={cn('h-4 w-4 transition-transform', collapsed && 'rotate-180')} />
         </button>
       </div>
 
+      {/* Navigation */}
       <nav className="flex-1 space-y-1 p-2">
         {navigation.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
@@ -73,6 +82,7 @@ export function Sidebar() {
         })}
       </nav>
 
+      {/* Bottom section: notifications + user */}
       <div className="space-y-1 border-t p-2">
         <Link
           href="/dashboard/notifications"
@@ -84,6 +94,36 @@ export function Sidebar() {
           <Bell className="h-5 w-5 shrink-0" />
           {!collapsed && <span>Notifications</span>}
         </Link>
+
+        {/* User info and logout */}
+        {user && (
+          <div
+            className={cn(
+              'flex items-center gap-3 rounded-lg px-3 py-2',
+              collapsed && 'justify-center px-2',
+            )}
+          >
+            <div className="bg-primary/10 text-primary flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-medium">
+              {user.displayName?.charAt(0) ?? user.email.charAt(0).toUpperCase()}
+            </div>
+            {!collapsed && (
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{user.displayName ?? user.email}</p>
+                <p className="text-muted-foreground truncate text-xs">{user.email}</p>
+              </div>
+            )}
+            <button
+              onClick={() => {
+                void logout();
+              }}
+              className="text-muted-foreground hover:text-destructive shrink-0 rounded-md p-1 transition-colors"
+              title="Log out"
+              aria-label="Log out"
+            >
+              <LogOut className="h-4 w-4" />
+            </button>
+          </div>
+        )}
       </div>
     </aside>
   );

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -1,0 +1,6 @@
+'use client';
+
+import { useAuth } from '@/lib/auth';
+
+// Re-export the hook from the canonical location
+export { useAuth };

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { apiFetch, clearAccessToken, storeAccessToken } from './api-client';
+
+interface User {
+  id: string;
+  email: string;
+  displayName: string | null;
+  role: string;
+}
+
+interface AuthState {
+  user: User | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, displayName?: string) => Promise<void>;
+  logout: () => Promise<void>;
+  refreshAuth: () => Promise<void>;
+}
+
+interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface AuthResponse extends TokenPair {
+  user: User;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+const REFRESH_TOKEN_KEY = 'veridion_refresh_token';
+const USER_KEY = 'veridion_user';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const router = useRouter();
+
+  const storeSession = useCallback((tokens: TokenPair, nextUser: User) => {
+    if (typeof window !== 'undefined') {
+      storeAccessToken(tokens.accessToken);
+      localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
+      localStorage.setItem(USER_KEY, JSON.stringify(nextUser));
+    }
+    setUser(nextUser);
+  }, []);
+
+  const clearSession = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      clearAccessToken();
+      localStorage.removeItem(REFRESH_TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
+    }
+    setUser(null);
+  }, []);
+
+  const refreshAuth = useCallback(async () => {
+    const refreshToken =
+      typeof window !== 'undefined' ? localStorage.getItem(REFRESH_TOKEN_KEY) : null;
+
+    if (!refreshToken) {
+      setUser(null);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const tokens = await apiFetch<TokenPair>('/auth/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ refreshToken }),
+      });
+      storeAccessToken(tokens.accessToken);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
+      }
+    } catch {
+      clearSession();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [clearSession]);
+
+  // Restore session on mount
+  useEffect(() => {
+    const storedUser = typeof window !== 'undefined' ? localStorage.getItem(USER_KEY) : null;
+    if (storedUser) {
+      try {
+        setUser(JSON.parse(storedUser) as User);
+      } catch {
+        // Ignore malformed stored user
+      }
+    }
+    void refreshAuth();
+  }, [refreshAuth]);
+
+  // Periodically refresh the token while authenticated
+  useEffect(() => {
+    if (!user) return;
+    const interval = setInterval(
+      () => {
+        void refreshAuth();
+      },
+      10 * 60 * 1000,
+    );
+    return () => clearInterval(interval);
+  }, [user, refreshAuth]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      const response = await apiFetch<AuthResponse>('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+      });
+      storeSession(response, response.user);
+    },
+    [storeSession],
+  );
+
+  const register = useCallback(
+    async (email: string, password: string, displayName?: string) => {
+      const response = await apiFetch<AuthResponse>('/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({ email, password, displayName }),
+      });
+      storeSession(response, response.user);
+    },
+    [storeSession],
+  );
+
+  const logout = useCallback(async () => {
+    try {
+      await apiFetch<{ message: string }>('/auth/logout', { method: 'POST' });
+    } catch {
+      // Ignore logout failures — clear the local session regardless
+    }
+    clearSession();
+    router.push('/login');
+  }, [clearSession, router]);
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      isLoading,
+      isAuthenticated: !!user,
+      login,
+      register,
+      logout,
+      refreshAuth,
+    }),
+    [user, isLoading, login, register, logout, refreshAuth],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary

Connects the login and register pages to the real API and adds client-side auth state (issue #35).

## Changes

- `AuthProvider` context with login/register/logout and token refresh.
- `ProtectedRoute` wrapper guarding the dashboard.
- `use-auth` hook re-exporting the canonical `useAuth`.
- Zod form validation on login/register using `@veridion/shared` schemas.
- Show user info + logout in the sidebar.
- Reuses the shared `api-client` and `veridion_access_token` key for consistency.

Closes #35
