### PR TITLE
feat: add environment variable validation and documentation (#41)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,40 +1,114 @@
-# Veridion Environment Configuration
+# ==============================================================================
+# Veridion Environment Variables
+# ------------------------------------------------------------------------------
+# Copy this file to `.env` (and/or `.env.local` for the web app) and adjust
+# the values for your environment.
+#
+#   API:  apps/api/.env          (or root .env when running via docker-compose)
+#   Web:  apps/web/.env.local    (NEXT_PUBLIC_* variables only)
+#
+# Legend:
+#   [REQUIRED]  Must be set — the application fails to start without it.
+#   [OPTIONAL]  Has a safe default and can be omitted.
+#   (dev only)  Only needed for local development.
+# ==============================================================================
 
-# Application
-NODE_ENV=development
-PORT=4000
-CORS_ORIGIN=http://localhost:3000
 
-# Database
+# ==============================================================================
+# Database (PostgreSQL)
+# ==============================================================================
+# [REQUIRED] Connection string for the PostgreSQL database.
 DATABASE_URL=postgresql://veridion:veridion@localhost:5432/veridion
 
-# Redis
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_URL=redis://localhost:6379
 
-# JWT Authentication
-JWT_SECRET=your-jwt-secret-change-in-production
+# ==============================================================================
+# Redis
+# ==============================================================================
+# [OPTIONAL] Redis host used by the BullMQ job queue. Defaults to localhost.
+REDIS_HOST=localhost
+# [OPTIONAL] Redis port. Defaults to 6379.
+REDIS_PORT=6379
+# [OPTIONAL] Full Redis URL (alternative to REDIS_HOST/REDIS_PORT).
+# REDIS_URL=redis://localhost:6379
+
+
+# ==============================================================================
+# Auth (JWT)
+# ==============================================================================
+# [REQUIRED] Secret used to sign access tokens.
+#   Generate a strong value in production, e.g.: openssl rand -base64 48
+JWT_SECRET=dev-secret
+# [REQUIRED] Secret used to sign refresh tokens.
+JWT_REFRESH_SECRET=dev-refresh-secret
+# [OPTIONAL] Access token lifetime. Defaults to 15m.
 JWT_EXPIRATION=15m
-JWT_REFRESH_SECRET=your-refresh-secret-change-in-production
+# [OPTIONAL] Refresh token lifetime. Defaults to 7d.
 JWT_REFRESH_EXPIRATION=7d
 
-# AI Providers
-AI_PROVIDER=openai
-OPENAI_API_KEY=sk-your-openai-api-key
-ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key
 
-# Stellar / Soroban
-STELLAR_NETWORK=TESTNET
+# ==============================================================================
+# AI Provider
+# ==============================================================================
+# [OPTIONAL] Which AI provider to use: `openai` or `anthropic`. Defaults to openai.
+AI_PROVIDER=openai
+# [OPTIONAL] OpenAI API key (required when AI_PROVIDER=openai).
+# OPENAI_API_KEY=sk-...
+# [OPTIONAL] Anthropic API key (required when AI_PROVIDER=anthropic).
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ==============================================================================
+# Blockchain (Stellar Soroban)
+# ==============================================================================
+# [OPTIONAL] Stellar network: `testnet`, `mainnet`, or `futurenet`. Defaults to testnet.
+STELLAR_NETWORK=testnet
+# [OPTIONAL] Stellar Soroban RPC URL.
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+# [OPTIONAL] Soroban signer secret key (required for on-chain audit registration).
 STELLAR_SECRET_KEY=your-testnet-soroban-signer-secret
+# [OPTIONAL] Audit registry contract ID on Soroban.
 STELLAR_AUDIT_REGISTRY_CONTRACT_ID=CDZLMOM3IPXG7FFHMVYGR3LFU6L36WQAMXGCRY2BYHSRCYRYAOVYPIWL
+# [OPTIONAL] Verifier contract ID on Soroban.
 STELLAR_VERIFIER_CONTRACT_ID=CBCMGBNKFABLSPUFR2D344HC6Z42C5FTLOZUTA3PCIYYE45AVD3RI5OP
+# [OPTIONAL] Max retries for Soroban operations. Defaults to 3.
 STELLAR_MAX_RETRIES=3
+# [OPTIONAL] Poll interval for Soroban operations (ms). Defaults to 3000.
 STELLAR_POLL_INTERVAL_MS=3000
+# [OPTIONAL] Veridion release version. Defaults to 1.0.0.
 VERIDION_VERSION=1.0.0
 
-# Frontend (Next.js)
+
+# ==============================================================================
+# Email (SMTP)
+# ==============================================================================
+# [OPTIONAL] SMTP server host for transactional email notifications.
+# SMTP_HOST=smtp.example.com
+# [OPTIONAL] SMTP server port.
+# SMTP_PORT=587
+# [OPTIONAL] SMTP username.
+# SMTP_USER=no-reply@example.com
+# [OPTIONAL] SMTP password.
+# SMTP_PASSWORD=
+# [OPTIONAL] From address for outgoing emails.
+# EMAIL_FROM=Veridion <no-reply@example.com>
+
+
+# ==============================================================================
+# Runtime
+# ==============================================================================
+# [OPTIONAL] Node environment: `development`, `test`, or `production`.
+NODE_ENV=development
+# [OPTIONAL] Port the API listens on. Defaults to 4000.
+PORT=4000
+# [OPTIONAL] Allowed CORS origin. Defaults to the web app's localhost URL.
+CORS_ORIGIN=http://localhost:3000
+
+
+# ==============================================================================
+# Web (Next.js) — public variables exposed to the browser
+# ==============================================================================
+# [OPTIONAL] The publicly reachable URL of the web app. Defaults to localhost:3000.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://localhost:4000/api/v1
-NEXT_PUBLIC_STELLAR_NETWORK=TESTNET
+# [OPTIONAL] The publicly reachable base URL of the API. Defaults to localhost:4000.
+NEXT_PUBLIC_API_URL=http://localhost:4000
+# [OPTIONAL] Stellar network used by the web app. Defaults to testnet.
+NEXT_PUBLIC_STELLAR_NETWORK=testnet

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,7 +50,8 @@
     "passport-headerapikey": "^1.2.2",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.3.2",

--- a/apps/api/src/config/validation.ts
+++ b/apps/api/src/config/validation.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+/**
+ * Environment variable schema for the Veridion API.
+ *
+ * Required variables are marked with no `.optional()` and a `default()`.
+ * In production, secrets must be provided; in development they fall back
+ * to safe local defaults.
+ */
+const envSchema = z.object({
+  // ---- Runtime ----
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().int().min(1).max(65535).default(4000),
+  CORS_ORIGIN: z.string().url('CORS_ORIGIN must be a valid URL').default('http://localhost:3000'),
+
+  // ---- Database ----
+  DATABASE_URL: z
+    .string()
+    .min(1, 'DATABASE_URL is required')
+    .refine((val) => /^postgres(ql)?:\/\//.test(val), {
+      message: 'DATABASE_URL must be a valid PostgreSQL connection string',
+    }),
+
+  // ---- Redis ----
+  REDIS_HOST: z.string().default('localhost'),
+  REDIS_PORT: z.coerce.number().int().min(1).max(65535).default(6379),
+  REDIS_URL: z.string().url('REDIS_URL must be a valid URL').optional(),
+
+  // ---- Auth (JWT) ----
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required').default('dev-secret'),
+  JWT_REFRESH_SECRET: z
+    .string()
+    .min(1, 'JWT_REFRESH_SECRET is required')
+    .default('dev-refresh-secret'),
+  JWT_EXPIRATION: z.string().default('15m'),
+  JWT_REFRESH_EXPIRATION: z.string().default('7d'),
+
+  // ---- AI ----
+  AI_PROVIDER: z.enum(['openai', 'anthropic']).default('openai'),
+  OPENAI_API_KEY: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+
+  // ---- Blockchain (Stellar Soroban) ----
+  STELLAR_NETWORK: z
+    .string()
+    .default('testnet')
+    .transform((value) => value.toLowerCase())
+    .refine((value) => ['testnet', 'mainnet', 'futurenet'].includes(value), {
+      message: 'STELLAR_NETWORK must be one of: testnet, mainnet, futurenet',
+    }),
+  STELLAR_RPC_URL: z.string().url('STELLAR_RPC_URL must be a valid URL').optional(),
+
+  // ---- Email ----
+  SMTP_HOST: z.string().optional(),
+  SMTP_PORT: z.coerce.number().int().min(1).max(65535).optional(),
+  SMTP_USER: z.string().optional(),
+  SMTP_PASSWORD: z.string().optional(),
+  EMAIL_FROM: z.string().email('EMAIL_FROM must be a valid email').optional(),
+});
+
+export type EnvConfig = z.infer<typeof envSchema>;
+
+/**
+ * Parse and validate environment variables.
+ * Throws an Error with a human-readable list of all validation failures.
+ */
+export function validateEnv(): EnvConfig {
+  const result = envSchema.safeParse(process.env);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  - ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('\n');
+
+    throw new Error(
+      `Invalid environment configuration:\n${issues}\n\n` +
+        'Please review your .env file. See .env.example for a complete reference.',
+    );
+  }
+
+  // Extra guard: in production, do not allow the insecure default secrets.
+  if (result.data.NODE_ENV === 'production') {
+    const insecureSecrets = [
+      { key: 'JWT_SECRET', value: result.data.JWT_SECRET },
+      { key: 'JWT_REFRESH_SECRET', value: result.data.JWT_REFRESH_SECRET },
+    ].filter(({ value }) => value === 'dev-secret' || value === 'dev-refresh-secret');
+
+    if (insecureSecrets.length > 0) {
+      throw new Error(
+        `Insecure secrets detected in production: ${insecureSecrets.map((s) => s.key).join(', ')}. ` +
+          'Set strong secrets via environment variables.',
+      );
+    }
+  }
+
+  return result.data;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,8 +5,13 @@ import { logger } from '@veridion/logger';
 import helmet from 'helmet';
 
 import { AppModule } from './app.module';
+import { validateEnv } from './config/validation';
 
 async function bootstrap() {
+  // Validate environment variables on startup.
+  const env = validateEnv();
+  process.env.PORT = String(env.PORT);
+
   const app = await NestFactory.create(AppModule);
 
   // Security

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,40 @@
 /** @type {import('next').NextConfig} */
+
+// Validate `NEXT_PUBLIC_*` environment variables at build time.
+// (Kept inline here because next.config.js is CommonJS and is evaluated
+// before TypeScript compilation, so it cannot import .ts files.)
+const { z } = require('zod');
+
+const envSchema = z.object({
+  NEXT_PUBLIC_APP_URL: z
+    .string()
+    .url('NEXT_PUBLIC_APP_URL must be a valid URL')
+    .default('http://localhost:3000'),
+  NEXT_PUBLIC_API_URL: z
+    .string()
+    .url('NEXT_PUBLIC_API_URL must be a valid URL')
+    .default('http://localhost:4000'),
+  NEXT_PUBLIC_STELLAR_NETWORK: z.enum(['testnet', 'mainnet', 'futurenet']).default('testnet'),
+});
+
+const parsedEnv = envSchema.safeParse({
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  NEXT_PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+});
+
+if (!parsedEnv.success) {
+  const issues = parsedEnv.error.issues
+    .map((issue) => `  - ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('\n');
+  // eslint-disable-next-line no-console
+  console.error(
+    `Invalid web environment configuration:\n${issues}\n\n` +
+      'Please review your .env file. See .env.example for a complete reference.',
+  );
+  process.exit(1);
+}
+
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ['@veridion/ui', '@veridion/shared', '@veridion/sdk'],

--- a/apps/web/src/config/validation.ts
+++ b/apps/web/src/config/validation.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+/**
+ * Environment variable schema for the Veridion web app.
+ *
+ * Only `NEXT_PUBLIC_*` variables are exposed to the browser.
+ * These are validated at build time.
+ */
+const envSchema = z.object({
+  NEXT_PUBLIC_APP_URL: z
+    .string()
+    .url('NEXT_PUBLIC_APP_URL must be a valid URL')
+    .default('http://localhost:3000'),
+  NEXT_PUBLIC_API_URL: z
+    .string()
+    .url('NEXT_PUBLIC_API_URL must be a valid URL')
+    .default('http://localhost:4000'),
+  NEXT_PUBLIC_STELLAR_NETWORK: z.enum(['testnet', 'mainnet', 'futurenet']).default('testnet'),
+});
+
+export type WebEnvConfig = z.infer<typeof envSchema>;
+
+/**
+ * Parse and validate public environment variables.
+ * Throws an Error with a human-readable list of all validation failures.
+ */
+export function validateWebEnv(): WebEnvConfig {
+  const result = envSchema.safeParse({
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+    NEXT_PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+  });
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  - ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('\n');
+
+    throw new Error(
+      `Invalid web environment configuration:\n${issues}\n\n` +
+        'Please review your .env file. See .env.example for a complete reference.',
+    );
+  }
+
+  return result.data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.3.2


### PR DESCRIPTION
## Summary

Adds environment variable validation and documentation (issue #41).

## Changes
- `.env.example` documenting all variables grouped by service.
- Zod-based env schema for the API, validated on startup (`main.ts`).
- Zod-based validation for web `NEXT_PUBLIC_*` vars, validated at build time (`next.config.js`).
- Add `zod` as an API dependency.

Closes #41