### PR TITLE
feat(docker): complete full-stack Docker Compose setup (#40)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,43 @@
-version: '3.8'
+# ---------------------------------------------------------------------------
+# Veridion full-stack development environment.
+#
+#   docker compose up -d
+#
+# Starts: PostgreSQL, Redis, API (NestJS), and Web (Next.js).
+# The API runs Prisma migrations (`db push`) automatically on startup.
+# See `.env.example` for a full reference of available environment variables.
+# ---------------------------------------------------------------------------
 
 services:
   postgres:
     image: postgres:16-alpine
     container_name: veridion-db
     environment:
-      POSTGRES_USER: veridion
-      POSTGRES_PASSWORD: veridion
-      POSTGRES_DB: veridion
+      POSTGRES_USER: ${POSTGRES_USER:-veridion}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-veridion}
+      POSTGRES_DB: ${POSTGRES_DB:-veridion}
     ports:
-      - '5432:5432'
+      - '${POSTGRES_PORT:-5432}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U veridion']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-veridion}']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
 
   redis:
     image: redis:7-alpine
     container_name: veridion-redis
     ports:
-      - '6379:6379'
+      - '${REDIS_PORT:-6379}:6379'
     volumes:
       - redis_data:/data
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
 
   api:
     build:
@@ -37,21 +45,51 @@ services:
       dockerfile: docker/Dockerfile.api
     container_name: veridion-api
     ports:
-      - '4000:4000'
+      - '${PORT:-4000}:4000'
     environment:
-      NODE_ENV: development
-      DATABASE_URL: postgresql://veridion:veridion@postgres:5432/veridion
+      NODE_ENV: ${NODE_ENV:-development}
+      PORT: 4000
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+      # Database
+      DATABASE_URL: postgresql://${POSTGRES_USER:-veridion}:${POSTGRES_PASSWORD:-veridion}@postgres:5432/${POSTGRES_DB:-veridion}
+      # Redis
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       REDIS_URL: redis://redis:6379
-      JWT_SECRET: dev-jwt-secret-change-in-production
-      JWT_REFRESH_SECRET: dev-refresh-secret-change-in-production
+      # Auth
+      JWT_SECRET: ${JWT_SECRET:-dev-secret}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:-dev-refresh-secret}
+      JWT_EXPIRATION: ${JWT_EXPIRATION:-15m}
+      JWT_REFRESH_EXPIRATION: ${JWT_REFRESH_EXPIRATION:-7d}
+      # AI
+      AI_PROVIDER: ${AI_PROVIDER:-openai}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Blockchain
+      STELLAR_NETWORK: ${STELLAR_NETWORK:-testnet}
+      STELLAR_RPC_URL: ${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}
+      # Email
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      EMAIL_FROM: ${EMAIL_FROM:-}
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
-    volumes:
-      - .:/app
-      - /app/node_modules
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:4000/api/v1/health'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
 
   web:
     build:
@@ -61,12 +99,24 @@ services:
     ports:
       - '3000:3000'
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:4000/api/v1
+      NODE_ENV: ${NODE_ENV:-development}
+      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:4000}
+      NEXT_PUBLIC_STELLAR_NETWORK: ${NEXT_PUBLIC_STELLAR_NETWORK:-testnet}
     depends_on:
-      - api
-    volumes:
-      - .:/app
-      - /app/node_modules
+      api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3000'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
 
 volumes:
   postgres_data:

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -3,6 +3,9 @@ RUN corepack enable && corepack prepare pnpm@9.1.0 --activate
 
 FROM base AS builder
 WORKDIR /app
+# Use a hoisted (flat) node_modules layout so the runtime image can copy
+# node_modules directly without pnpm's nested symlink structure.
+ENV npm_config_node_linker=hoisted
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
 COPY packages ./packages
 COPY apps/api ./apps/api
@@ -11,9 +14,21 @@ RUN pnpm turbo build --filter=@veridion/api
 
 FROM base AS runner
 WORKDIR /app
+RUN apk add --no-cache openssl
+
+# Copy the built API and its dependencies
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/apps/api/dist ./apps/api/dist
 COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
 
+# Copy all workspace packages (built dist + prisma schema) so the pnpm
+# workspace symlinks in node_modules resolve correctly at runtime and
+# migrations can run via the database package's Prisma CLI.
+COPY --from=builder /app/packages ./packages
+
+# Copy the migration entrypoint
+COPY docker/entrypoint.api.sh ./entrypoint.api.sh
+RUN chmod +x ./entrypoint.api.sh
+
 EXPOSE 4000
-CMD ["node", "apps/api/dist/main.js"]
+ENTRYPOINT ["./entrypoint.api.sh"]

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -3,6 +3,9 @@ RUN corepack enable && corepack prepare pnpm@9.1.0 --activate
 
 FROM base AS builder
 WORKDIR /app
+# Use a hoisted (flat) node_modules layout so the runtime image can copy
+# node_modules directly without pnpm's nested symlink structure.
+ENV npm_config_node_linker=hoisted
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
 COPY packages ./packages
 COPY apps/web ./apps/web
@@ -14,7 +17,11 @@ WORKDIR /app
 COPY --from=builder /app/apps/web/.next ./apps/web/.next
 COPY --from=builder /app/apps/web/public ./apps/web/public
 COPY --from=builder /app/apps/web/package.json ./apps/web/package.json
+COPY --from=builder /app/apps/web/next.config.js ./apps/web/next.config.js
 COPY --from=builder /app/node_modules ./node_modules
+# Copy all workspace packages so the pnpm workspace symlinks resolve at runtime.
+COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 EXPOSE 3000
 CMD ["pnpm", "--filter", "@veridion/web", "start"]

--- a/docker/entrypoint.api.sh
+++ b/docker/entrypoint.api.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+echo "🚀 Starting Veridion API..."
+
+SCHEMA="${PRISMA_SCHEMA_PATH:-packages/database/prisma/schema.prisma}"
+
+# Locate the Prisma CLI. pnpm nests it under the database package's bin;
+# fall back to the root node_modules bin and `npx` as a last resort.
+if [ -x "packages/database/node_modules/.bin/prisma" ]; then
+  PRISMA="packages/database/node_modules/.bin/prisma"
+elif [ -x "node_modules/.bin/prisma" ]; then
+  PRISMA="node_modules/.bin/prisma"
+else
+  PRISMA="npx prisma"
+fi
+
+echo "⏳ Applying database schema (using: $PRISMA)..."
+
+attempt=0
+max_attempts=30
+until $PRISMA db push --schema "$SCHEMA" --skip-generate --accept-data-loss; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "❌ Database not reachable after ${max_attempts} attempts. Exiting."
+    exit 1
+  fi
+  echo "⏳ Database not ready yet (attempt ${attempt}/${max_attempts}) — retrying in 2s..."
+  sleep 2
+done
+
+echo "✅ Database schema is up to date."
+
+# Start the API server.
+exec node apps/api/dist/main.js


### PR DESCRIPTION
## Summary

Completes the Docker Compose setup for the full stack (issue #40).

## Changes
- Health checks for all services.
- Auto-run Prisma `db push` on API startup via an entrypoint script.
- Document env vars with safe defaults.
- Use `node-linker=hoisted` for reliable production images and copy workspace packages so pnpm symlinks resolve.

Closes #40