### PR TITLE
feat(web): connect notifications page to API

### DIFF
--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Put, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Put, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -18,6 +18,7 @@ export class NotificationsController {
     return this.notificationsService.findAll(userId);
   }
 
+  @Patch(':id/read')
   @Put(':id/read')
   @ApiOperation({ summary: 'Mark notification as read' })
   markRead(@Param('id') id: string, @CurrentUser('id') userId: string) {

--- a/apps/web/src/app/dashboard/notifications/page.tsx
+++ b/apps/web/src/app/dashboard/notifications/page.tsx
@@ -8,143 +8,208 @@ import {
   Clock,
   ExternalLink,
   Info,
+  Loader2,
+  RefreshCw,
   XCircle,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { apiGet, apiPatch } from '@/lib/api-helpers';
+import { formatRelativeTime } from '@/lib/utils';
+
 type NotificationType = 'INFO' | 'SUCCESS' | 'WARNING' | 'ERROR';
+type NotificationFilter = 'all' | 'unread';
 
 interface Notification {
   id: string;
   title: string;
   message: string;
-  type: NotificationType;
+  type: string;
   read: boolean;
   link: string | null;
   createdAt: string;
 }
 
-const notifications: Notification[] = [
-  {
-    id: 'n1',
-    title: 'Audit Completed',
-    message:
-      'Security audit for DeFi Protocol v2 has completed with a score of 82/100. 14 findings were identified.',
-    type: 'SUCCESS',
-    read: false,
-    link: '/dashboard/audits/a1',
-    createdAt: '2024-06-15 10:35',
-  },
-  {
-    id: 'n2',
-    title: 'Critical Finding Detected',
-    message:
-      'A critical reentrancy vulnerability was found in LiquidityPool.sol:45-58. Immediate action recommended.',
-    type: 'ERROR',
-    read: false,
-    link: '/dashboard/audits/a1',
-    createdAt: '2024-06-15 10:32',
-  },
-  {
-    id: 'n3',
-    title: 'Blockchain Verification Complete',
-    message:
-      'Your audit for Staking Rewards has been verified on Stellar Soroban. Transaction hash: stellar-tx-789012.',
-    type: 'SUCCESS',
-    read: false,
-    link: '/dashboard/audits/a2',
-    createdAt: '2024-06-03 09:15',
-  },
-  {
-    id: 'n4',
-    title: 'AI Analysis Available',
-    message:
-      'AI-powered analysis is now available for your latest NFT Marketplace audit. Chat with AI to explore findings.',
-    type: 'INFO',
-    read: true,
-    link: '/dashboard/ai-chat',
-    createdAt: '2024-05-29 14:00',
-  },
-  {
-    id: 'n5',
-    title: 'Audit Failed',
-    message:
-      'The audit for Token Vesting contract failed due to compilation errors. Please check your contract and try again.',
-    type: 'ERROR',
-    read: true,
-    link: '/dashboard/audits/a4',
-    createdAt: '2024-05-20 16:45',
-  },
-  {
-    id: 'n6',
-    title: 'Weekly Security Digest',
-    message:
-      'This week: 3 audits completed, 25 findings resolved, average security score improved by 5 points.',
-    type: 'INFO',
-    read: true,
-    link: null,
-    createdAt: '2024-05-19 08:00',
-  },
-  {
-    id: 'n7',
-    title: 'New Plugin Available',
-    message:
-      'The "Front-Running Detection" plugin has been added. Enable it in your project settings to detect MEV vulnerabilities.',
-    type: 'INFO',
-    read: true,
-    link: '/dashboard/settings',
-    createdAt: '2024-05-15 12:00',
-  },
-  {
-    id: 'n8',
-    title: 'API Key Generated',
-    message: 'A new API key "production-key" was generated for programmatic access to Veridion.',
-    type: 'WARNING',
-    read: true,
-    link: '/dashboard/settings',
-    createdAt: '2024-05-10 10:30',
-  },
-];
+interface NotificationGroup {
+  label: string;
+  items: Notification[];
+}
 
-const typeConfig: Record<NotificationType, { icon: React.ElementType; color: string; bg: string }> =
-  {
-    INFO: { icon: Info, color: 'text-blue-500', bg: 'bg-blue-500/10' },
-    SUCCESS: { icon: CheckCircle2, color: 'text-emerald-500', bg: 'bg-emerald-500/10' },
-    WARNING: { icon: AlertTriangle, color: 'text-amber-500', bg: 'bg-amber-500/10' },
-    ERROR: { icon: XCircle, color: 'text-red-500', bg: 'bg-red-500/10' },
-  };
+const typeConfig: Record<
+  NotificationType,
+  { icon: React.ElementType; color: string; bg: string; border: string }
+> = {
+  INFO: {
+    icon: Info,
+    color: 'text-blue-500',
+    bg: 'bg-blue-500/10',
+    border: 'border-blue-500/20',
+  },
+  SUCCESS: {
+    icon: CheckCircle2,
+    color: 'text-emerald-500',
+    bg: 'bg-emerald-500/10',
+    border: 'border-emerald-500/20',
+  },
+  WARNING: {
+    icon: AlertTriangle,
+    color: 'text-amber-500',
+    bg: 'bg-amber-500/10',
+    border: 'border-amber-500/20',
+  },
+  ERROR: {
+    icon: XCircle,
+    color: 'text-red-500',
+    bg: 'bg-red-500/10',
+    border: 'border-red-500/20',
+  },
+};
+
+function getTypeConfig(type: string) {
+  return typeConfig[type.toUpperCase() as NotificationType] ?? typeConfig.INFO;
+}
 
 export default function NotificationsPage() {
-  const [items, setItems] = useState(notifications);
-  const [filter, setFilter] = useState<'all' | 'unread'>('all');
+  const [items, setItems] = useState<Notification[]>([]);
+  const [filter, setFilter] = useState<NotificationFilter>('all');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+  const requestId = useRef(0);
 
-  const filtered = filter === 'unread' ? items.filter((n) => !n.read) : items;
-  const unreadCount = items.filter((n) => !n.read).length;
+  const loadNotifications = useCallback(async () => {
+    const currentRequestId = ++requestId.current;
+    setLoading(true);
+    setError(null);
 
-  function markAsRead(id: string) {
-    setItems((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+    try {
+      const response = await apiGet<unknown>('/api/v1/notifications');
+      if (!Array.isArray(response)) {
+        throw new Error('Unexpected notifications response');
+      }
+      if (currentRequestId === requestId.current) setItems(response as Notification[]);
+    } catch (err) {
+      if (currentRequestId === requestId.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load notifications');
+      }
+    } finally {
+      if (currentRequestId === requestId.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadNotifications();
+  }, [loadNotifications]);
+
+  const unreadCount = items.filter((notification) => !notification.read).length;
+  const groups = useMemo<NotificationGroup[]>(() => {
+    const visibleItems = filter === 'unread' ? items.filter((item) => !item.read) : items;
+    const unread = visibleItems.filter((item) => !item.read);
+    const read = visibleItems.filter((item) => item.read);
+
+    return [
+      ...(unread.length > 0 ? [{ label: 'Unread', items: unread }] : []),
+      ...(read.length > 0 ? [{ label: 'Earlier', items: read }] : []),
+    ];
+  }, [filter, items]);
+
+  async function markAsRead(id: string) {
+    const notification = items.find((item) => item.id === id);
+    if (!notification || notification.read || pendingIds.has(id)) return true;
+
+    setPendingIds((current) => new Set(current).add(id));
+    setItems((current) => current.map((item) => (item.id === id ? { ...item, read: true } : item)));
+
+    try {
+      await apiPatch(`/api/v1/notifications/${id}/read`);
+      return true;
+    } catch (err) {
+      setItems((current) =>
+        current.map((item) => (item.id === id ? { ...item, read: false } : item)),
+      );
+      toast.error(err instanceof Error ? err.message : 'Failed to mark notification as read');
+      return false;
+    } finally {
+      setPendingIds((current) => {
+        const next = new Set(current);
+        next.delete(id);
+        return next;
+      });
+    }
   }
 
-  function markAllAsRead() {
-    setItems((prev) => prev.map((n) => ({ ...n, read: true })));
-    toast.success('All notifications marked as read');
+  async function markAllAsRead() {
+    const unread = items.filter((item) => !item.read);
+    if (unread.length === 0) return;
+
+    const results = await Promise.all(unread.map((item) => markAsRead(item.id)));
+    if (results.every(Boolean)) toast.success('All notifications marked as read');
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6" aria-busy="true" aria-label="Loading notifications">
+        <div>
+          <div className="bg-muted h-9 w-56 animate-pulse rounded-md" />
+          <div className="bg-muted mt-3 h-5 w-96 max-w-full animate-pulse rounded-md" />
+        </div>
+        <div className="bg-card divide-y overflow-hidden rounded-xl border">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="flex gap-4 px-6 py-5">
+              <div className="bg-muted h-10 w-10 shrink-0 animate-pulse rounded-lg" />
+              <div className="flex-1 space-y-3">
+                <div className="bg-muted h-4 w-1/3 animate-pulse rounded" />
+                <div className="bg-muted h-4 w-4/5 animate-pulse rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[26rem] flex-col items-center justify-center text-center">
+        <div className="bg-destructive/10 text-destructive flex h-14 w-14 items-center justify-center rounded-2xl">
+          <Bell className="h-7 w-7" />
+        </div>
+        <h1 className="mt-5 text-xl font-semibold">Could not load notifications</h1>
+        <p className="text-muted-foreground mt-2 max-w-sm text-sm">{error}</p>
+        <button
+          type="button"
+          onClick={() => void loadNotifications()}
+          className="text-primary mt-5 inline-flex items-center gap-2 text-sm font-medium hover:underline"
+        >
+          <RefreshCw className="h-4 w-4" /> Try again
+        </button>
+      </div>
+    );
   }
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Notifications</h1>
+          <p className="text-primary text-sm font-semibold uppercase tracking-wider">Activity</p>
+          <h1 className="mt-1 text-3xl font-bold tracking-tight">Notifications</h1>
           <p className="text-muted-foreground mt-1">
             Stay updated on audits, findings, and platform activity.
           </p>
         </div>
 
-        <div className="flex items-center gap-3">
-          <div className="bg-muted flex rounded-lg p-1">
+        <div className="flex flex-wrap items-center gap-3">
+          <div
+            className="bg-muted flex rounded-lg p-1"
+            role="tablist"
+            aria-label="Notification filter"
+          >
             <button
+              type="button"
+              role="tab"
+              aria-selected={filter === 'all'}
               onClick={() => setFilter('all')}
               className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                 filter === 'all'
@@ -155,6 +220,9 @@ export default function NotificationsPage() {
               All
             </button>
             <button
+              type="button"
+              role="tab"
+              aria-selected={filter === 'unread'}
               onClick={() => setFilter('unread')}
               className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                 filter === 'unread'
@@ -168,99 +236,143 @@ export default function NotificationsPage() {
 
           {unreadCount > 0 && (
             <button
-              onClick={markAllAsRead}
-              className="hover:bg-muted inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors"
+              type="button"
+              onClick={() => void markAllAsRead()}
+              disabled={pendingIds.size > 0}
+              className="hover:bg-muted inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <CheckCheck className="h-4 w-4" />
+              {pendingIds.size > 0 ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCheck className="h-4 w-4" />
+              )}
               Mark all read
             </button>
           )}
         </div>
       </div>
 
-      {filtered.length === 0 ? (
-        <div className="bg-card flex flex-col items-center justify-center rounded-xl border py-16">
-          <Bell className="text-muted-foreground/30 h-12 w-12" />
-          <p className="text-muted-foreground mt-4 text-lg font-medium">No notifications</p>
-          <p className="text-muted-foreground text-sm">
+      {groups.length === 0 ? (
+        <div className="bg-card flex flex-col items-center justify-center rounded-xl border px-6 py-16 text-center">
+          <div className="bg-primary/10 text-primary flex h-14 w-14 items-center justify-center rounded-2xl">
+            <Bell className="h-7 w-7" />
+          </div>
+          <h2 className="mt-5 text-lg font-semibold">
+            {filter === 'unread' ? 'You are all caught up' : 'No notifications yet'}
+          </h2>
+          <p className="text-muted-foreground mt-1 max-w-sm text-sm">
             {filter === 'unread'
               ? 'You have read all your notifications.'
-              : "You haven't received any notifications yet."}
+              : "We'll let you know when there is activity on your account."}
           </p>
         </div>
       ) : (
-        <div className="bg-card rounded-xl border">
-          <div className="divide-y">
-            {filtered.map((notification) => {
-              const config = typeConfig[notification.type] ?? typeConfig.INFO;
-              const Icon = config.icon;
-
-              return (
-                <div
-                  key={notification.id}
-                  className={`hover:bg-muted/50 group flex items-start gap-4 px-6 py-4 transition-colors ${
-                    !notification.read ? 'bg-muted/20' : ''
-                  }`}
+        <div className="space-y-6">
+          {groups.map((group) => (
+            <section
+              key={group.label}
+              aria-labelledby={`${group.label.toLowerCase()}-notifications`}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <h2
+                  id={`${group.label.toLowerCase()}-notifications`}
+                  className="text-sm font-semibold uppercase tracking-wider"
                 >
-                  <div
-                    className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${config.bg}`}
-                  >
-                    <Icon className={`h-5 w-5 ${config.color}`} />
-                  </div>
+                  {group.label}
+                </h2>
+                <span className="text-muted-foreground text-xs">
+                  {group.items.length} notification{group.items.length === 1 ? '' : 's'}
+                </span>
+              </div>
 
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-start justify-between gap-2">
-                      <div>
-                        <p className="font-medium">
-                          {notification.title}
-                          {!notification.read && (
-                            <span className="bg-primary ml-2 inline-block h-2 w-2 rounded-full" />
-                          )}
-                        </p>
-                        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-sm">
-                          {notification.message}
-                        </p>
-                      </div>
+              <div className="bg-card overflow-hidden rounded-xl border shadow-sm">
+                <div className="divide-y">
+                  {group.items.map((notification) => {
+                    const config = getTypeConfig(notification.type);
+                    const Icon = config.icon;
+                    const isPending = pendingIds.has(notification.id);
 
-                      <div className="flex shrink-0 items-center gap-2">
-                        <span className="text-muted-foreground flex items-center gap-1 text-xs">
-                          <Clock className="h-3 w-3" />
-                          {notification.createdAt.split(' ')[0]}
-                        </span>
-                      </div>
-                    </div>
-
-                    <div className="mt-2 flex items-center gap-2">
-                      {notification.link && (
-                        <Link
-                          href={notification.link}
-                          className="text-primary inline-flex items-center gap-1 text-xs font-medium hover:underline"
+                    return (
+                      <article
+                        key={notification.id}
+                        className={`hover:bg-muted/50 group flex items-start gap-4 px-5 py-5 transition-colors sm:px-6 ${
+                          !notification.read ? 'bg-muted/20' : ''
+                        }`}
+                      >
+                        <div
+                          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border ${config.bg} ${config.border}`}
                         >
-                          View details
-                          <ExternalLink className="h-3 w-3" />
-                        </Link>
-                      )}
+                          <Icon className={`h-5 w-5 ${config.color}`} aria-hidden="true" />
+                        </div>
 
-                      {!notification.read && (
-                        <button
-                          onClick={() => markAsRead(notification.id)}
-                          className="text-muted-foreground hover:text-foreground text-xs transition-colors"
-                        >
-                          Mark as read
-                        </button>
-                      )}
-                    </div>
-                  </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <h3 className="font-medium">
+                                {notification.title}
+                                {!notification.read && (
+                                  <span
+                                    className="bg-primary ml-2 inline-block h-2 w-2 rounded-full align-middle"
+                                    aria-label="Unread"
+                                  />
+                                )}
+                              </h3>
+                              <p className="text-muted-foreground mt-1 text-sm leading-6">
+                                {notification.message}
+                              </p>
+                            </div>
+
+                            <span
+                              className="text-muted-foreground flex shrink-0 items-center gap-1 text-xs"
+                              title={new Date(notification.createdAt).toLocaleString()}
+                            >
+                              <Clock className="h-3 w-3" aria-hidden="true" />
+                              <span className="hidden sm:inline">
+                                {formatRelativeTime(notification.createdAt)}
+                              </span>
+                              <span className="sm:hidden">
+                                {formatRelativeTime(notification.createdAt, { short: true })}
+                              </span>
+                            </span>
+                          </div>
+
+                          <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+                            {notification.link && (
+                              <Link
+                                href={notification.link}
+                                className="text-primary inline-flex items-center gap-1 text-xs font-medium hover:underline"
+                              >
+                                View details
+                                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                              </Link>
+                            )}
+
+                            {!notification.read && (
+                              <button
+                                type="button"
+                                onClick={() => void markAsRead(notification.id)}
+                                disabled={isPending}
+                                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                              >
+                                {isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+                                Mark as read
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      </article>
+                    );
+                  })}
                 </div>
-              );
-            })}
-          </div>
+              </div>
+            </section>
+          ))}
         </div>
       )}
 
       <div className="bg-card rounded-xl border p-4 text-center">
         <p className="text-muted-foreground text-sm">
-          Showing {filtered.length} of {items.length} notifications
+          Showing {filter === 'unread' ? unreadCount : items.length} of {items.length} notifications
           {unreadCount > 0 && ` · ${unreadCount} unread`}
         </p>
       </div>

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { cn, formatAddress, severityColor } from './utils';
+import { cn, formatAddress, formatRelativeTime, severityColor } from './utils';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('cn', () => {
   it('should merge class names', () => {
@@ -23,6 +27,20 @@ describe('formatAddress', () => {
     const result = formatAddress('GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890');
     expect(result).toContain('...');
     expect(result.length).toBeLessThan(44);
+  });
+});
+
+describe('formatRelativeTime', () => {
+  it('formats recent dates relative to the current time', () => {
+    vi.setSystemTime(new Date('2026-08-12T12:00:00.000Z'));
+
+    expect(formatRelativeTime('2026-08-12T10:00:00.000Z')).toBe('2 hours ago');
+    expect(formatRelativeTime('2026-08-12T12:00:00.000Z')).toBe('just now');
+    expect(formatRelativeTime('2026-08-12T13:00:00.000Z', { short: true })).toBe('1h from now');
+  });
+
+  it('handles invalid dates', () => {
+    expect(formatRelativeTime('not-a-date')).toBe('Unknown time');
   });
 });
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -18,6 +18,36 @@ export function formatAddress(address: string, chars = 6): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
 
+export function formatRelativeTime(date: string | Date, options: { short?: boolean } = {}): string {
+  const timestamp = new Date(date).getTime();
+  if (Number.isNaN(timestamp)) return 'Unknown time';
+
+  const elapsedSeconds = Math.round((timestamp - Date.now()) / 1000);
+  const units = [
+    { name: 'year', seconds: 31_536_000 },
+    { name: 'month', seconds: 2_592_000 },
+    { name: 'week', seconds: 604_800 },
+    { name: 'day', seconds: 86_400 },
+    { name: 'hour', seconds: 3_600 },
+    { name: 'minute', seconds: 60 },
+    { name: 'second', seconds: 1 },
+  ];
+  const unit = units.find(({ seconds }) => Math.abs(elapsedSeconds) >= seconds);
+
+  if (!unit) return options.short ? 'now' : 'just now';
+
+  const value = Math.round(elapsedSeconds / unit.seconds);
+  if (options.short) {
+    const suffix = value > 0 ? 'from now' : 'ago';
+    return `${Math.abs(value)}${unit.name[0]} ${suffix}`;
+  }
+
+  return new Intl.RelativeTimeFormat('en', { numeric: 'always' }).format(
+    value,
+    unit.name as Intl.RelativeTimeFormatUnit,
+  );
+}
+
 export function severityColor(severity: string): string {
   const colors: Record<string, string> = {
     CRITICAL: 'text-red-500 bg-red-500/10',


### PR DESCRIPTION
## Summary
- connect the dashboard notifications page to the authenticated notifications API
- add read/unread grouping, filtering, relative timestamps, links, and loading/error/empty states
- persist mark-as-read actions with PATCH and retain PUT compatibility

## Validation
- format check, lint, typecheck, full tests, and production build pass

Closes #36